### PR TITLE
Fix for issue #10 (namespace/window/mumble)

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -66,7 +66,7 @@ var TWEEN = TWEEN || ( function () {
 
 	};
 
-} )();
+} ).call({});
 
 TWEEN.Tween = function ( object ) {
 


### PR DESCRIPTION
This seems to fix the issue - window no longer contains the TWEEN methods, and window.TWEEN is its own object with the proper members.
