### PR TITLE
Allow to synchronize to an external timeline (e.g. video)

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -57,7 +57,7 @@ var TWEEN = TWEEN || ( function () {
 		update: function (_time) {
 
 			i = 0; tl = tweens.length;
-			time = time || new Date().getTime();
+			time = _time || new Date().getTime();
 
 			while ( i < tl ) {
 


### PR DESCRIPTION
Add _time to TWEEN.update and to TWEEN.Tween.start to allow synchronizing with an external timeline
