### PR TITLE
Declare `num_tweens` variable

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -11,7 +11,7 @@
 
 var TWEEN = TWEEN || ( function () {
 
-	var i, tl, interval, time, fps = 60, autostart = false, tweens = [];
+	var i, tl, interval, time, fps = 60, autostart = false, tweens = [], num_tweens;
 
 	return {
 	


### PR DESCRIPTION
The `num_tweens` variable was being used without being declared.
