### PR TITLE
Fixes a scoping issue related to autostart/autostop.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -34,6 +34,8 @@ var TWEEN = TWEEN || ( function () {
 		stop: function () {
 
 			clearInterval( interval );
+			
+			interval = null;
 
 		},
 


### PR DESCRIPTION
When TWEEN.update() is called as a result of the update interval it's called in the scope of Window, so this.stop() causes an error.
