### PR TITLE
fix error after stopping tween inside onUpdate

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -65,11 +65,11 @@ var TWEEN = TWEEN || ( function () {
 
 			if ( _tweens.length === 0 ) return false;
 
-			var i = 0, numTweens = _tweens.length;
+			var i = 0;
 
 			time = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
 
-			while ( i < numTweens ) {
+			while ( i < _tweens.length ) {
 
 				if ( _tweens[ i ].update( time ) ) {
 
@@ -78,8 +78,6 @@ var TWEEN = TWEEN || ( function () {
 				} else {
 
 					_tweens.splice( i, 1 );
-
-					numTweens --;
 
 				}
 


### PR DESCRIPTION
It is possible to stop tween inside onUpdate callback. So it changes internal _tweens array and it's length, and cached length in TWEEN.update becomes obsolete. And if this tween wasn't last, there will be error.

In this example:

``` javascript
var tween  = new TWEEN.Tween({})
var second = new TWEEN.Tween({})

tween.onUpdate(function() { tween.stop() })

tween .to({}, 500).start()
second.to({}, 500).start()

TWEEN.update()
```

a "TypeError: Cannot call method 'update' of undefined" will be thrown
