### PR TITLE
Add repeatDelay

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -100,6 +100,7 @@ TWEEN.Tween = function ( object ) {
 	var _valuesStartRepeat = {};
 	var _duration = 1000;
 	var _repeat = 0;
+	var _repeatDelayTime = undefined;
 	var _yoyo = false;
 	var _reversed = false;
 	var _delayTime = 0;
@@ -189,6 +190,13 @@ TWEEN.Tween = function ( object ) {
 	this.repeat = function ( times ) {
 
 		_repeat = times;
+		return this;
+
+	};
+
+	this.repeatDelay = function ( amount ) {
+
+		_repeatDelayTime = amount;
 		return this;
 
 	};
@@ -326,7 +334,11 @@ TWEEN.Tween = function ( object ) {
 
 				}
 
-				_startTime = time + _delayTime;
+				if (_repeatDelayTime !== undefined) {
+					_startTime = time + _repeatDelayTime;
+				} else {
+					_startTime = time + _delayTime;
+				}
 
 				return true;
 

--- a/test/unit/TestTweens.js
+++ b/test/unit/TestTweens.js
@@ -595,3 +595,93 @@ test( "Test yoyo with repeat 1 happens once", function() {
 	TWEEN.update( 225 );
 	equal( obj.x, 0 );
 });
+
+// If repeatDelay isn't specified then delay is used since
+// that's the way it worked before repeatDelay was added.
+
+test( "Test delay adds delay before each repeat", function() {
+
+	TWEEN.removeAll();
+
+	var obj = { x: 0 },
+		t = new TWEEN.Tween( obj ).to( { x: 100 }, 100 ).repeat( 1 ).delay(100);
+
+	t.start( 0 );
+
+	TWEEN.update( 100 );
+	equal( obj.x, 0 );
+
+	TWEEN.update( 150 );
+	equal( obj.x, 50 );
+
+	TWEEN.update( 200 );
+	equal( obj.x, 100 );
+
+	TWEEN.update( 300 );
+	equal( obj.x, 0 );
+
+	TWEEN.update( 350 );
+	equal( obj.x, 50 );
+
+	TWEEN.update( 400 );
+	equal( obj.x, 100 );
+
+});
+
+test( "Test repeatDelay adds delay before each repeat", function() {
+
+	TWEEN.removeAll();
+
+	var obj = { x: 0 },
+		t = new TWEEN.Tween( obj ).to( { x: 100 }, 100 ).repeat( 1 ).repeatDelay(200);
+
+	t.start( 0 );
+
+	TWEEN.update( 0 );
+	equal( obj.x, 0 );
+
+	TWEEN.update( 50 );
+	equal( obj.x, 50 );
+
+	TWEEN.update( 100 );
+	equal( obj.x, 100 );
+
+	TWEEN.update( 300 );
+	equal( obj.x, 0 );
+
+	TWEEN.update( 350 );
+	equal( obj.x, 50 );
+
+	TWEEN.update( 400 );
+	equal( obj.x, 100 );
+
+});
+
+test( "Test repeatDelay and delay can be used together", function() {
+
+	TWEEN.removeAll();
+
+	var obj = { x: 0 },
+		t = new TWEEN.Tween( obj ).to( { x: 100 }, 100 ).delay(100).repeat( 1 ).repeatDelay(200);
+
+	t.start( 0 );
+
+	TWEEN.update( 100 );
+	equal( obj.x, 0 );
+
+	TWEEN.update( 150 );
+	equal( obj.x, 50 );
+
+	TWEEN.update( 200 );
+	equal( obj.x, 100 );
+
+	TWEEN.update( 400 );
+	equal( obj.x, 0 );
+
+	TWEEN.update( 450 );
+	equal( obj.x, 50 );
+
+	TWEEN.update( 500 );
+	equal( obj.x, 100 );
+
+});


### PR DESCRIPTION
repeatDelay is used to control the delay time between each repeat.  This
is useful if, for example, you want to have a 2 second delay between
each repeat but you want the Tween to start immediately. The current
delay method will cause the Tween to delay 2 seconds before starting.