### PR TITLE
Fix Tween synchronization when using repeat.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -100,10 +100,12 @@ TWEEN.Tween = function ( object ) {
 	var _valuesStartRepeat = {};
 	var _duration = 1000;
 	var _repeat = 0;
+	var _repeats = 0;
 	var _yoyo = false;
 	var _reversed = false;
 	var _delayTime = 0;
 	var _startTime = null;
+	var _originalStartTime = null;
 	var _easingFunction = TWEEN.Easing.Linear.None;
 	var _interpolationFunction = TWEEN.Interpolation.Linear;
 	var _chainedTweens = [];
@@ -141,6 +143,8 @@ TWEEN.Tween = function ( object ) {
 
 		_startTime = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
 		_startTime += _delayTime;
+
+		_originalStartTime = _startTime;
 
 		for ( var property in _valuesEnd ) {
 
@@ -309,6 +313,8 @@ TWEEN.Tween = function ( object ) {
 					_repeat--;
 				}
 
+				_repeats += 1;
+
 				// reassign starting values, restart by making startTime = now
 				for( property in _valuesStartRepeat ) {
 
@@ -326,7 +332,7 @@ TWEEN.Tween = function ( object ) {
 
 				}
 
-				_startTime = time + _delayTime;
+				_startTime = _originalStartTime + _repeats * (_duration + _delayTime);
 
 				return true;
 


### PR DESCRIPTION
The current method of calculating repeat _startTime can cause Tweens to
fall out of sync. The current calculation is dependent on the update
time that triggers the repeat, not the original _startTime and _duration
of the Tween.  This issue can be readily observed by 1) creating two
Tweens with different durations, 2) setting them to repeat, and 3)
starting them at the same time. They slowing fall out of sync.

Fix: _originalStartTime, number of _repeats and _duration are used to
calculate a consistent repeat _startTime. _delayTime is also taken into
account.