### PR TITLE
made _valuesStart only inherit applicable properties, not everything

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -115,7 +115,13 @@ TWEEN.Tween = function ( object ) {
 	// Set all starting values present on the target object
 	for ( var field in object ) {
 
-		_valuesStart[ field ] = parseFloat(object[field], 10);
+		var value = parseFloat( object[ field ], 10 );
+		var type = toString.call( value );
+
+		// Only add properties that are numbers or arrays
+		if ( type == '[object Number]' || type == '[object Array]' ) {
+			_valuesStart[ field ] = value;
+		}
 
 	}
 


### PR DESCRIPTION
Currently nested objects append `NaN` to the `_valuesStart` object. This check makes sure that only appropriate properties are inherited.
