### PR TITLE
Complete a tween rather than just stopping it.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -185,6 +185,13 @@ TWEEN.Tween = function ( object ) {
 		return this;
 
 	};
+	
+	this.end = function () {
+	  
+		this.update(_duration);
+		return this;
+		
+	};
 
 	this.stopChainedTweens = function () {
 


### PR DESCRIPTION
I added a end function. It should run the last frame of the tween and then the onComplete function like normal. This is better than stopping in some cases so that elements that are moving are not left in between states.