### PR TITLE
Move the _reversed yoyo flag outside of the property loop.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -350,10 +350,13 @@ TWEEN.Tween = function ( object ) {
 						var tmp = _valuesStartRepeat[ property ];
 						_valuesStartRepeat[ property ] = _valuesEnd[ property ];
 						_valuesEnd[ property ] = tmp;
-						_reversed = !_reversed;
 					}
 					_valuesStart[ property ] = _valuesStartRepeat[ property ];
 
+				}
+
+				if (_yoyo) {
+					_reversed = !_reversed;
 				}
 
 				_startTime = time + _delayTime;


### PR DESCRIPTION
It should be updated just once, not for each property.
Previously it was only correct when using an odd number of properties.
