### PR TITLE
add from method for some use-cases

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -137,6 +137,10 @@ TWEEN.Tween = function ( object ) {
 		if (!_valuesStart){
 			// If user not assign from-properties, Set all starting values present on the target object
 			this.from(_object);
+		} else {
+			for (var property in _valuesStart) {
+				_object[property] = _valuesStart[property];
+			}
 		}
 
 		TWEEN.add( this );

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -88,9 +88,9 @@ var TWEEN = TWEEN || ( function () {
 TWEEN.Tween = function ( object ) {
 
 	var _object = object;
-	var _valuesStart = {};
+	var _valuesStart = null;
 	var _valuesEnd = {};
-	var _valuesStartRepeat = {};
+	var _valuesStartRepeat = null;
 	var _duration = 1000;
 	var _repeat = 0;
 	var _yoyo = false;
@@ -107,12 +107,16 @@ TWEEN.Tween = function ( object ) {
 	var _onCompleteCallback = null;
 	var _onStopCallback = null;
 
-	// Set all starting values present on the target object
-	for ( var field in object ) {
+	this.from = function( properties ){
+		_valuesStart = {};
+		_valuesStartRepeat = {};
 
-		_valuesStart[ field ] = parseFloat(object[field], 10);
-
-	}
+		for ( var field in properties ) {
+			_valuesStart[ field ] = parseFloat(properties[field], 10);
+		}
+		
+		return this;
+	};
 
 	this.to = function ( properties, duration ) {
 
@@ -129,6 +133,11 @@ TWEEN.Tween = function ( object ) {
 	};
 
 	this.start = function ( time ) {
+
+		if (!_valuesStart){
+			// If user not assign from-properties, Set all starting values present on the target object
+			this.from(_object);
+		}
 
 		TWEEN.add( this );
 


### PR DESCRIPTION
In some use-cases , the object's fields are not  _valueStart ,so maybe user want to do something like this:

```
new TWEEN.Tween( obejct ).from( {x:20, y:20}).to({x:100,y:100}).start();

```
