### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+assets/
+docs/
+examples/
+test/
+utils/
+
+.gitignore
+.npmignore
+.travis.yml
+CONTRIBUTING.md
+gulpfile.js


### PR DESCRIPTION
Please include `build/tween.min.js` in the npm package. The `.npmignore` ignores everything but:

* `src/*`
* `build/*`
* `package.json`
* `LICENSE`
* `README.md`

I hope this makes your release process a little bit easier :)
(Sorry about the spam; enjoy your weekend)

See: jsdelivr/jsdelivr#1506

**Edit/more info**

jsDelivr is a CDN for open source projects. You including `tween.min.js` in the npm package means jsDelivr can auto-update the files every time you publish a new release and people who use npm for fron-end stuff can also choose to use the minified version. You don't need to worry about any of this though. Just make sure you call `npm publish` from the root of the project when r15/0.15.0 is ready so npm can utilize the `.npmignore` file.

I added the `.npmignore` hoping that it makes your life easier (just publish to npm without doing things by hand like you currently do (the stuff inside `utils/`)). jsDelivr can figure out the releases even if you ignore this PR :)

If you'd like a sneak peek of what the `.npmignore` will do, clone my fork, checkout the `npm` branch and run `npm pack`. The tarball's contents are identical to the npm release you'd get when running `npm publish`.