### PR TITLE
Fix onStart to match user guide

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -286,6 +286,13 @@ TWEEN.Tween = function ( object ) {
 
 				_onStartCallback.call( _object );
 
+				// Reset all starting values, in case they were changed by the callback
+				for ( var field in _object ) {
+
+					_valuesStart[ field ] = parseFloat(_object[field], 10);
+
+				}
+
 			}
 
 			_onStartCallbackFired = true;


### PR DESCRIPTION
The user guide's reference to onStart doesn't work as expected (see http://jsfiddle.net/BryanMorgan/trL3k6j1/ for an example). This change simply resets the _valuesStart object if the onStart callback is fired in case the values are changed inside the callback.