### PR TITLE
Array.prototype.indexOf shim

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -18,6 +18,19 @@ if ( Date.now === undefined ) {
 
 }
 
+// fix when TWEEN.remove(this) on IE7, IE8
+if (Array.prototype.indexOf === undefined) {
+	Array.prototype.indexOf = function (arr) {
+		var value = -1;
+		for (var i = 0; i < this.length; i++) {
+			if (this[i] === arr) {
+				value = i;
+			}
+		}
+		return value;
+	};
+}
+
 var TWEEN = TWEEN || ( function () {
 
 	var _tweens = [];


### PR DESCRIPTION
IE5, IE6, IE7 and IE8 doesn't support native Array.indexOf. No problem, we can add shim and works nice.