### PR TITLE
allow FP style callbacks by applying _object

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -180,7 +180,7 @@ TWEEN.Tween = function ( object ) {
 
 		if ( _onStopCallback !== null ) {
 
-			_onStopCallback.call( _object );
+			_onStopCallback.call( _object, _object );
 
 		}
 
@@ -284,7 +284,7 @@ TWEEN.Tween = function ( object ) {
 
 			if ( _onStartCallback !== null ) {
 
-				_onStartCallback.call( _object );
+				_onStartCallback.call( _object, _object );
 
 			}
 
@@ -365,7 +365,7 @@ TWEEN.Tween = function ( object ) {
 
 				if ( _onCompleteCallback !== null ) {
 
-					_onCompleteCallback.call( _object );
+					_onCompleteCallback.call( _object, _object );
 
 				}
 


### PR DESCRIPTION
this way, its easier for functional programmers to say
tween…..onComplete(Level.destroy).start()

While Level.destroy accepts an object as method, while Level is just a namespace for functions.

Usually in FP, the data is applied as last param for more flexibility, see Ramda.js vs the wrong way in _underscore

https://www.youtube.com/watch?v=m3svKOdZijA

Hope this wont break something else but so far i havent gotten any problems.

Cheers!