### PR TITLE
Tween.speed

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -196,6 +196,10 @@ If `time` is not specified, it will use the current time.
 
 Used to get a reference to the active `tweens` array and to remove all of them from the array with just one call, respectively.
 
+### `TWEEEN.speed(speed)`
+
+Used to control the overall speed of all tweens, currently running and future. Value of 1 is default, value of 2 is twice as fast, etc. Will change speed of running tweens smoothly.
+
 ### `TWEEN.add(tween)` and `TWEEN.remove(tween)`
 
 Used to add a tween to the list of active tweens, or to remove an specific one from the list, respectively.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -87,7 +87,7 @@ var tween = new TWEEN.Tween(position)
 	.start();
 ````
 
-You'll see this a lot in the examples, so it's good to be familiar with it! Check [04-simplest](./examples/04_simplest.html) for a working example.
+You'll see this a lot in the examples, so it's good to be familiar with it! Check [04-simplest](../examples/04_simplest.html) for a working example.
 
 ## Animating with tween.js
 

--- a/examples/13_speed.html
+++ b/examples/13_speed.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Tween.js / yoyo</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<link href="css/style.css" media="screen" rel="stylesheet" type="text/css" />
+	</head>
+	<body>
+		<div id="info">
+			<h1><a href="http://github.com/sole/tween.js">tween.js</a></h1>
+			<h2>13 _ speed</h2>
+			<p>Demonstrating the speed() feature.</p>
+			<p/>
+			<p> Use the slider to set global speed: </p> <input type="range" id="speed" oninput="changespeed()" min=2 max=30 value=10></input>
+		</div>
+		<div style="position: absolute; top: 100px; left: 400px; ">
+			<div id="target1" data-rotation="0" data-y="0" class="box" style="left: 0px; top: 0px">
+				slow yoyo
+			</div>
+			<div id="target2" data-rotation="0" data-y="0" class="box" style="left: 300px; top: 0px">
+				fast yoyo
+			</div>
+		</div>
+
+ <!-- <script src="../build/tween.min.js"></script>  Not changing minified version of script as requested in contribution instructions. -->
+ 		<script src="../src/Tween.js"> </script>
+		<script src="js/RequestAnimationFrame.js"></script>
+		<script>
+
+			init();
+			animate();
+
+			function init() {
+				var target1 = document.getElementById( 'target1' ),
+					tween1 = new TWEEN.Tween( target1.dataset )
+						.to( { rotation: 360, y: 300 }, 1000 )
+						.repeat( Infinity )
+						.delay( 1000 )
+						.yoyo( true )
+						.easing( TWEEN.Easing.Cubic.InOut )
+						.onUpdate( function() {
+							updateBox( target1, this );
+						})
+						.start(),
+					target2 = document.getElementById( 'target2' ),
+					tween2 = new TWEEN.Tween( target2.dataset )
+						.to( { rotation: 360, y:300 }, 500 )
+						.repeat( Infinity )
+						.delay( 500 )
+						.yoyo( true )
+						.easing( TWEEN.Easing.Cubic.InOut )
+						.onUpdate( function() {
+							updateBox( target2, this );
+						})
+						.start();
+			}
+
+			function animate( time ) {
+
+				requestAnimationFrame( animate );
+
+				TWEEN.update( time );
+
+			}
+
+			function updateBox( box, params ) {
+
+				var s = box.style,
+					transform = 'rotate(' + Math.floor( params.rotation ) + 'deg)';
+				s.webkitTransform = transform;
+				s.mozTransform = transform;
+				s.transform = transform;
+
+				box.style.top = params.y + 'px';
+			}
+
+			function changespeed() {
+
+				TWEEN.speed(document.getElementById('speed').value / 10);
+
+			}
+
+		</script>
+
+		<style type="text/css">
+			.box {
+				width: 100px;
+				height: 100px;
+				display: block;
+				-webkit-border-radius: 70px;
+				-moz-border-radius: 70px;
+				border-radius: 70px;
+				position: absolute;
+				border: 1px solid black;
+				font-size: 10px;
+				padding: 20px;
+			}
+			#target1 {
+				background: #fcc;
+			}
+			#target2 {
+				background: #cfc;
+			}
+		</style>
+	</body>
+</html>
+
+

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -63,6 +63,7 @@ var TWEEN = TWEEN || ( function () {
 			var i = 0;
 
 			time = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
+			time = ( time - this._speedChangeStartAbsolute ) * this._speed + this._speedChangeStartRelative;
 
 			while ( i < _tweens.length ) {
 
@@ -79,6 +80,23 @@ var TWEEN = TWEEN || ( function () {
 			}
 
 			return true;
+
+		},
+
+		_speed: 1,
+
+		_speedChangeStartAbsolute: 0,
+
+		_speedChangeStartRelative: 0,
+
+		speed: function (speed) {
+
+			var time = typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now();
+
+			this._speedChangeStartRelative += (time - this._speedChangeStartAbsolute) * this._speed;
+			this._speedChangeStartAbsolute = time;
+
+			this._speed = speed;
 
 		}
 	};
@@ -136,7 +154,18 @@ TWEEN.Tween = function ( object ) {
 
 		_onStartCallbackFired = false;
 
-		_startTime = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
+		if (time == undefined) {
+
+			time = ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
+
+			_startTime = ( time - TWEEN._speedChangeStartAbsolute ) * TWEEN._speed + TWEEN._speedChangeStartRelative;
+
+		} else {
+
+			_startTime = time;
+
+		}
+
 		_startTime += _delayTime;
 
 		for ( var property in _valuesEnd ) {
@@ -271,7 +300,6 @@ TWEEN.Tween = function ( object ) {
 	};
 
 	this.update = function ( time ) {
-
 		var property;
 
 		if ( time < _startTime ) {
@@ -293,6 +321,7 @@ TWEEN.Tween = function ( object ) {
 		}
 
 		var elapsed = ( time - _startTime ) / _duration;
+
 		elapsed = elapsed > 1 ? 1 : elapsed;
 
 		var value = _easingFunction( elapsed );
@@ -357,12 +386,14 @@ TWEEN.Tween = function ( object ) {
 					_reversed = !_reversed;
 				}
 
-				_startTime = time + _delayTime;
+				_startTime = time;
+				_startTime += _delayTime;
 
 				return true;
 
 			} else {
 
+				// if ( _onCompleteCallback ) {
 				if ( _onCompleteCallback !== null ) {
 
 					_onCompleteCallback.call( _object );
@@ -754,6 +785,9 @@ TWEEN.Interpolation = {
 
 };
 
+
 if(typeof module !== 'undefined' && module.exports) {
+
 	module.exports = TWEEN;
+
 }


### PR DESCRIPTION
Added function for controlling the global speed of all running and future tweens.

Unlike the in-development timescale function, which if applied to a running tween can cause behavior such as running backwards, TWEEN.speed() allows for granular, rapid speed changes across the whole TWEEN environment.

Simply call TWEEN.speed(2) to run tweens twice as fast, TWEEN.speed(0.5) for half as fast, etc.

Included are a test and an example HTML.

Changes made only to Tween.js in src because contributors were asked not to check in tween.min.js. Link in the example HTML is to Tween.js in src - this needs to be changed when tween.js is re-minified. (Should I have done this, too?)