### PR TITLE
Add performance.now polyfill

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -7,16 +7,28 @@
  * Thank you all, you're awesome!
  */
 
-// Date.now shim for (ahem) Internet Explo(d|r)er
-if ( Date.now === undefined ) {
+// performance.now polyfill
+( function ( root ) {
 
-	Date.now = function () {
+	if ( 'performance' in root === false ) {
+		root.performance = {};
+	}
 
-		return new Date().valueOf();
+	// IE 8
+	Date.now = ( Date.now || function () {
+		return new Date().getTime();
+	} );
 
-	};
+	if ( 'now' in root.performance === false ) {
+		var offset = root.performance.timing && root.performance.timing.navigationStart ? performance.timing.navigationStart
+		                                                                                : Date.now();
 
-}
+		root.performance.now = function () {
+			return Date.now() - offset;
+		};
+	}
+
+} )( this );
 
 var TWEEN = TWEEN || ( function () {
 
@@ -62,7 +74,7 @@ var TWEEN = TWEEN || ( function () {
 
 			var i = 0;
 
-			time = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
+			time = time !== undefined ? time : window.performance.now();
 
 			while ( i < _tweens.length ) {
 
@@ -136,7 +148,7 @@ TWEEN.Tween = function ( object ) {
 
 		_onStartCallbackFired = false;
 
-		_startTime = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
+		_startTime = time !== undefined ? time : window.performance.now();
 		_startTime += _delayTime;
 
 		for ( var property in _valuesEnd ) {

--- a/test/unit/nodeunitheadless.js
+++ b/test/unit/nodeunitheadless.js
@@ -3,8 +3,16 @@ var TWEEN_uncompressed = require('../../src/Tween.js');
 var TWEEN_min = require('../../build/tween.min.js');
 var getTests = require('./tests');
 
+// Make the tests work outside of browsers.
+global.window = {
+	performance: {
+		now: function() {
+			return Date.now();
+		}
+	}
+};
+
 module.exports = {
 	'tween': getTests(TWEEN_uncompressed),
 	'tween_min': getTests(TWEEN_min)
 };
-


### PR DESCRIPTION
This should solve the problems people have with tween.js on iOS, as well as improve animation quality in older browsers in general.