### PR TITLE
Support for tween groups

### DIFF
--- a/examples/13_groups.html
+++ b/examples/13_groups.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Tween.js / stop chained</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<link href="css/style.css" media="screen" rel="stylesheet" type="text/css" />
+	</head>
+	<body>
+		<div id="info">
+			<h1><a href="http://github.com/sole/tween.js">tween.js</a></h1>
+			<h2>13 _ separate tweening groups.</h2>
+			<p>Click a widget to pause or resume.</p>
+		</div>
+		<div style="position: absolute; top: 250px; left: 50px; ">
+			<button id="add">Add Widget</button>
+			<button id="remove">Remove Widget</button>
+         <br/>
+         <br/>
+         <div id="widgetContainer"/>
+		</div>
+
+		<script src="../build/tween.min.js"></script>
+		<script src="js/RequestAnimationFrame.js"></script>
+		<script>
+         // The Box class represents the boxes that will move around in the widgets.
+         function Box() {
+            this.domElement = document.createElement("div");
+            this.domElement.className = "Box";
+            
+            this.x = 0;
+            this.y = 0;
+            
+            this.position = (function() {
+               this.domElement.style.left = this.x + "px";
+               this.domElement.style.top = this.y + "px";
+            }).bind(this);
+         }
+         
+         // A Widget is just a little box with boxes moving around in it. Nothing too fancy.
+         function Widget() {
+            var _tweenGroup = new TWEEN.TweenGroup();
+            
+            this.domElement = document.createElement("div");
+            this.domElement.className = "Widget";
+            
+            var _box1 = new Box();
+            _box1.x = 25;
+            _box1.y = 25;
+            _box1.position();
+            this.domElement.appendChild(_box1.domElement);
+            var _box1_right = _tweenGroup.createTween(_box1)
+               .to({x:125, y:25})
+               .onUpdate(_box1.position);
+            var _box1_down = _tweenGroup.createTween(_box1)
+               .to({x:125, y:125})
+               .onUpdate(_box1.position);
+            var _box1_left = _tweenGroup.createTween(_box1)
+               .to({x:25, y:125})
+               .onUpdate(_box1.position);
+            var _box1_up = _tweenGroup.createTween(_box1)
+               .to({x:25, y:25})
+               .onUpdate(_box1.position);
+            _box1_right.chain(_box1_down);
+            _box1_down.chain(_box1_left);
+            _box1_left.chain(_box1_up);
+            _box1_up.chain(_box1_right);
+            _box1_right.start();
+            
+            var _box2 = new Box();
+            _box2.x = 125;
+            _box2.y = 125;
+            _box2.position();
+            this.domElement.appendChild(_box2.domElement);
+            var _box2_right = _tweenGroup.createTween(_box2)
+               .to({x:125, y:25})
+               .onUpdate(_box2.position);
+            var _box2_down = _tweenGroup.createTween(_box2)
+               .to({x:125, y:125})
+               .onUpdate(_box2.position);
+            var _box2_left = _tweenGroup.createTween(_box2)
+               .to({x:25, y:125})
+               .onUpdate(_box2.position);
+            var _box2_up = _tweenGroup.createTween(_box2)
+               .to({x:25, y:25})
+               .onUpdate(_box2.position);
+            _box2_right.chain(_box2_down);
+            _box2_down.chain(_box2_left);
+            _box2_left.chain(_box2_up);
+            _box2_up.chain(_box2_right);
+            _box2_left.start();
+            
+            // TODO: pick up where the animation left off instead of jumping
+            var _paused = false;
+            var _shouldPause = false;
+            var _lastAnimationRequestID = undefined;
+            var _pauseStartTime;
+            var _totalPausedTime = 0;
+            
+            this.animate = (function(time) {
+               _tweenGroup.update(time - _totalPausedTime);
+               _lastAnimationTime = time;
+               _lastAnimationRequestID = requestAnimationFrame(this.animate);
+            }).bind(this);
+            
+            this.togglePaused = (function() {
+               if (_paused) {
+                  _lastAnimationRequestID = requestAnimationFrame(this.animate);
+                  _paused = false;
+                  _totalPausedTime += performance.now() - _pauseStartTime;
+               } else {
+                  if (_lastAnimationRequestID) {
+                     cancelAnimationFrame(_lastAnimationRequestID);
+                     _lastAnimationRequestID = undefined;
+                  }
+                  _paused = true;
+                  _pauseStartTime = performance.now();
+               }
+            }).bind(this);
+            
+            this.domElement.onclick = this.togglePaused;
+            
+            // Allow this widget to be garbage collected.
+            this.destroy = function() {
+               // Force the animation loop to stop.
+               this.animate = function() {};
+            };
+         }
+         
+         var add = document.getElementById("add");
+         var remove = document.getElementById("remove");
+         
+         var widgetContainer = document.getElementById("widgetContainer");
+         
+         var widgets = [];
+         
+         add.onclick = function() {
+            var widget = new Widget();
+            widgets.push(widget);
+            widgetContainer.appendChild(widget.domElement);
+            widget.animate()
+         };
+         
+         remove.onclick = function() {
+            var removedWidget = widgets.pop();
+            if (removedWidget) {
+               widgetContainer.removeChild(removedWidget.domElement);
+               removedWidget.destroy();
+            }
+         };
+		</script>
+
+		<style type="text/css">
+			.Box {
+				width: 50px;
+				height: 50px;
+            display: block;
+				-webkit-border-radius: 10px;
+				-moz-border-radius: 10px;
+				border-radius: 10px;
+				position: absolute;
+            background-color: #222;
+			}
+         
+         .Widget {
+            width: 200px;
+            height: 200px;
+            margin: -1px -1px 0px 0px;
+            float: left;
+            position: relative;
+				border: 1px solid black;
+            background-color: #CCC;
+         }
+		</style>
+	</body>
+</html>

--- a/examples/13_groups.html
+++ b/examples/13_groups.html
@@ -30,6 +30,8 @@
             this.x = 0;
             this.y = 0;
             
+            // This function is called when the tweens update to actually change the position of the
+            // box within the widget using css relative positioning.
             this.position = (function() {
                this.domElement.style.left = this.x + "px";
                this.domElement.style.top = this.y + "px";
@@ -38,16 +40,20 @@
          
          // A Widget is just a little box with boxes moving around in it. Nothing too fancy.
          function Widget() {
+            // Create a tween group for the two tween chains.
             var _tweenGroup = new TWEEN.TweenGroup();
             
             this.domElement = document.createElement("div");
             this.domElement.className = "Widget";
             
+            // Create the box that starts in the top left of the widget
             var _box1 = new Box();
             _box1.x = 25;
             _box1.y = 25;
             _box1.position();
             this.domElement.appendChild(_box1.domElement);
+            
+            // Note that '_tweenGroup.createTween(_box1)' is the same as 'new TWEEN.Tween(_box1, _tweenGroup)'
             var _box1_right = _tweenGroup.createTween(_box1)
                .to({x:125, y:25})
                .onUpdate(_box1.position);
@@ -60,12 +66,17 @@
             var _box1_up = _tweenGroup.createTween(_box1)
                .to({x:25, y:25})
                .onUpdate(_box1.position);
+            
+            // Set up the tweens in a chain loop
             _box1_right.chain(_box1_down);
             _box1_down.chain(_box1_left);
             _box1_left.chain(_box1_up);
             _box1_up.chain(_box1_right);
+            
+            // Start with a rightward motion
             _box1_right.start();
             
+            // Create the box that starts in the bottom right of the widget
             var _box2 = new Box();
             _box2.x = 125;
             _box2.y = 125;
@@ -89,9 +100,9 @@
             _box2_up.chain(_box2_right);
             _box2_left.start();
             
-            // TODO: pick up where the animation left off instead of jumping
+            // The rest of the code in this class has to do with pausing.
+            
             var _paused = false;
-            var _shouldPause = false;
             var _lastAnimationRequestID = undefined;
             var _pauseStartTime;
             var _totalPausedTime = 0;
@@ -122,7 +133,9 @@
             // Allow this widget to be garbage collected.
             this.destroy = function() {
                // Force the animation loop to stop.
-               this.animate = function() {};
+               if (_lastAnimationRequestID) {
+                  cancelAnimationFrame(_lastAnimationRequestID);
+               }
             };
          }
          
@@ -133,6 +146,8 @@
          
          var widgets = [];
          
+         // When the user clicks the "Add Widget" button, create a widget and append its
+         // domElement to the end of the container element.
          add.onclick = function() {
             var widget = new Widget();
             widgets.push(widget);
@@ -140,6 +155,7 @@
             widget.animate()
          };
          
+         // If there are any widgets left, remove the last one and destroy it.
          remove.onclick = function() {
             var removedWidget = widgets.pop();
             if (removedWidget) {

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -30,83 +30,89 @@
 
 } )( this );
 
-var _TWEEN_TweenGroup = function () {
+var TWEEN;
 
-	var _tweens = [];
+// Hide inside a local scope in order to avoid polluting the namespace
+(function () {
 
-   // TODO
-   //REVISION: '14',
+   var _TWEEN_TweenGroup = function () {
 
-   this.getAll = function () {
+      var _tweens = [];
 
-      return _tweens;
+      this.getAll = function () {
 
-   };
+         return _tweens;
 
-   this.removeAll = function () {
+      };
 
-      _tweens = [];
+      this.removeAll = function () {
 
-   };
+         _tweens = [];
 
-   this.add = function ( tween ) {
+      };
 
-      _tweens.push( tween );
+      this.add = function ( tween ) {
 
-   };
+         _tweens.push( tween );
 
-   this.remove = function ( tween ) {
+      };
 
-      var i = _tweens.indexOf( tween );
+      this.remove = function ( tween ) {
 
-      if ( i !== -1 ) {
+         var i = _tweens.indexOf( tween );
 
-         _tweens.splice( i, 1 );
-
-      }
-
-   };
-
-   this.update = function ( time ) {
-
-      if ( _tweens.length === 0 ) return false;
-
-      var i = 0;
-
-      time = time !== undefined ? time : window.performance.now();
-
-      while ( i < _tweens.length ) {
-
-         if ( _tweens[ i ].update( time ) ) {
-
-            i++;
-
-         } else {
+         if ( i !== -1 ) {
 
             _tweens.splice( i, 1 );
 
          }
 
-      }
+      };
 
-      return true;
+      this.update = function ( time ) {
 
-   };
-   
-   this.createTween = function ( object ) {
+         if ( _tweens.length === 0 ) return false;
+
+         var i = 0;
+
+         time = time !== undefined ? time : window.performance.now();
+
+         while ( i < _tweens.length ) {
+
+            if ( _tweens[ i ].update( time ) ) {
+
+               i++;
+
+            } else {
+
+               _tweens.splice( i, 1 );
+
+            }
+
+         }
+
+         return true;
+
+      };
       
-      return new TWEEN.Tween( object, this );
-   
+      this.createTween = function ( object ) {
+         
+         return new TWEEN.Tween( object, this );
+      
+      };
+
    };
+   
+   // For backwards compatibility, the TWEEN object is the global instance of TweenGroup.
+   // It is advisable to create your own instances of TweenGroup, in order to avoid using mutable global objects.
+   TWEEN = new _TWEEN_TweenGroup();
+   
+   // Don't expose the TweenGroup class directly, but rather expose it on the TWEEN object
+   TWEEN.TweenGroup = _TWEEN_TweenGroup;
+   
+})();
 
-};
-
-// For backwards compatibility, the TWEEN object is the global instance of TweenGroup
-var TWEEN = new _TWEEN_TweenGroup();
-
-// We don't want to expose the TweenGroup class directly, but rather expose it on the TWEEN object
-TWEEN.TweenGroup = _TWEEN_TweenGroup;
-delete _TWEEN_TweenGroup;
+TWEEN.REVISION = '14';
 
 TWEEN.Tween = function ( object, group ) {
 

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -30,76 +30,89 @@
 
 } )( this );
 
-var TWEEN = TWEEN || ( function () {
+var _TWEEN_TweenGroup = function () {
 
 	var _tweens = [];
 
-	return {
+   // TODO
+   //REVISION: '14',
 
-		REVISION: '14',
+   this.getAll = function () {
 
-		getAll: function () {
+      return _tweens;
 
-			return _tweens;
+   };
 
-		},
+   this.removeAll = function () {
 
-		removeAll: function () {
+      _tweens = [];
 
-			_tweens = [];
+   };
 
-		},
+   this.add = function ( tween ) {
 
-		add: function ( tween ) {
+      _tweens.push( tween );
 
-			_tweens.push( tween );
+   };
 
-		},
+   this.remove = function ( tween ) {
 
-		remove: function ( tween ) {
+      var i = _tweens.indexOf( tween );
 
-			var i = _tweens.indexOf( tween );
+      if ( i !== -1 ) {
 
-			if ( i !== -1 ) {
+         _tweens.splice( i, 1 );
 
-				_tweens.splice( i, 1 );
+      }
 
-			}
+   };
 
-		},
+   this.update = function ( time ) {
 
-		update: function ( time ) {
+      if ( _tweens.length === 0 ) return false;
 
-			if ( _tweens.length === 0 ) return false;
+      var i = 0;
 
-			var i = 0;
+      time = time !== undefined ? time : window.performance.now();
 
-			time = time !== undefined ? time : window.performance.now();
+      while ( i < _tweens.length ) {
 
-			while ( i < _tweens.length ) {
+         if ( _tweens[ i ].update( time ) ) {
 
-				if ( _tweens[ i ].update( time ) ) {
+            i++;
 
-					i++;
+         } else {
 
-				} else {
+            _tweens.splice( i, 1 );
 
-					_tweens.splice( i, 1 );
+         }
 
-				}
+      }
 
-			}
+      return true;
 
-			return true;
+   };
+   
+   this.createTween = function ( object ) {
+      
+      return new TWEEN.Tween( object, this );
+   
+   };
 
-		}
-	};
+};
 
-} )();
+// For backwards compatibility, the TWEEN object is the global instance of TweenGroup
+var TWEEN = new _TWEEN_TweenGroup();
 
-TWEEN.Tween = function ( object ) {
+// We don't want to expose the TweenGroup class directly, but rather expose it on the TWEEN object
+TWEEN.TweenGroup = _TWEEN_TweenGroup;
+delete _TWEEN_TweenGroup;
+
+TWEEN.Tween = function ( object, group ) {
 
 	var _object = object;
+   var _group = group === undefined ? TWEEN : group; // If no TweenGroup is specified, use the global one
+   
 	var _valuesStart = {};
 	var _valuesEnd = {};
 	var _valuesStartRepeat = {};
@@ -142,7 +155,7 @@ TWEEN.Tween = function ( object ) {
 
 	this.start = function ( time ) {
 
-		TWEEN.add( this );
+		_group.add( this );
 
 		_isPlaying = true;
 
@@ -187,7 +200,7 @@ TWEEN.Tween = function ( object ) {
 			return this;
 		}
 
-		TWEEN.remove( this );
+		_group.remove( this );
 		_isPlaying = false;
 
 		if ( _onStopCallback !== null ) {


### PR DESCRIPTION
In an attempt to fix a bug in another project, I realized that it would be useful if this library provided a way to keep track of separate groups of tweens. I tried out a couple different ways of refactoring the code. The one you see here is fairly minimal. It is based on the observation that the whole TWEEN object is basically just a big global group of tweens. So I just made it into a class called TweenGroup. The only substantial changes are that the Tween constructor can now take a TweenGroup (but defaults to the TWEEN global object, which is now an instance of TweenGroup with the rest of the global properties still thrown onto it), and there is a convenience method on TweenGroup called createTween that does the same thing. The whole purpose of TweenGroups is that they can be updated with separate times, which allows for selectively pausing tweens.

I have added three test cases, and all the tests still pass. I also added example 13 which demonstrates tween groups that can be updated and paused separately.

Please look through the code, and let me know if you have any questions. Thanks!