### PR TITLE
Ensure compatibility with ECMAScript 2015 modules

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -8,10 +8,10 @@
  */
 
 // performance.now polyfill
-( function ( root ) {
+( function () {
 
-	if ( 'performance' in root === false ) {
-		root.performance = {};
+	if ( 'performance' in window === false ) {
+		window.performance = {};
 	}
 
 	// IE 8
@@ -19,16 +19,16 @@
 		return new Date().getTime();
 	} );
 
-	if ( 'now' in root.performance === false ) {
-		var offset = root.performance.timing && root.performance.timing.navigationStart ? performance.timing.navigationStart
-		                                                                                : Date.now();
+	if ( 'now' in window.performance === false ) {
+		var offset = window.performance.timing && window.performance.timing.navigationStart ? window.performance.timing.navigationStart
+		                                                                                    : Date.now();
 
-		root.performance.now = function () {
+		window.performance.now = function () {
 			return Date.now() - offset;
 		};
 	}
 
-} )( this );
+} )();
 
 var TWEEN = TWEEN || ( function () {
 

--- a/test/unit/nodeunitheadless.js
+++ b/test/unit/nodeunitheadless.js
@@ -1,16 +1,11 @@
+// Make the tests work outside of browsers. The included polyfill will
+// automatically include a perf.now() implementation
+global.window = {};
+
 // We will unit test both the original library and the minified version
 var TWEEN_uncompressed = require('../../src/Tween.js');
 var TWEEN_min = require('../../build/tween.min.js');
 var getTests = require('./tests');
-
-// Make the tests work outside of browsers.
-global.window = {
-	performance: {
-		now: function() {
-			return Date.now();
-		}
-	}
-};
 
 module.exports = {
 	'tween': getTests(TWEEN_uncompressed),


### PR DESCRIPTION
The module evaluation context of ECMAScript 2015 modules is not the
global context. As such `this` does not point to the global `window`
object. This is problematic for users of ECMAScript 2015 modules as the
included `window.performance.now` polyfill will fail to work.

Instead of `this`, the polyfill should be added to the global `window`
object directly. This is unproblematic because the following code
assumes that `performance.now` will be available under the global
`window` object, i.e. the code was never execution environment agnostic.

Furthermore, established polyfills like the one from Paul Irish also
directly register the polyfill on the global `window` object.

Fixes #209

[1] https://gist.github.com/paulirish/5438650