### PR TITLE
Add tween groups using group keys.

### DIFF
--- a/examples/13_groups.html
+++ b/examples/13_groups.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <title>Tween.js / tween groups</title>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <link href="css/style.css" media="screen" rel="stylesheet" type="text/css" />
+   </head>
+   <body>
+      <div id="info">
+         <h1><a href="http://github.com/sole/tween.js">tween.js</a></h1>
+         <h2>13 _ separate tweening groups.</h2>
+         <p>Click a widget to pause or resume.</p>
+      </div>
+      <div style="position: absolute; top: 250px; left: 50px; ">
+         <button id="add">Add Widget</button>
+         <button id="remove">Remove Widget</button>
+         <br/>
+         <br/>
+         <div id="widgetContainer"/>
+      </div>
+
+      <script src="../build/tween.min.js"></script>
+      <script src="js/RequestAnimationFrame.js"></script>
+      <script>
+         // The Box class represents the boxes that will move around in the widgets.
+         function Box() {
+            this.domElement = document.createElement("div");
+            this.domElement.className = "Box";
+            
+            this.x = 0;
+            this.y = 0;
+            
+            // This function is called when the tweens update to actually change the position of the
+            // box within the widget using css relative positioning.
+            this.position = (function() {
+               this.domElement.style.left = this.x + "px";
+               this.domElement.style.top = this.y + "px";
+            }).bind(this);
+         }
+         
+         // A Widget is just a little box with boxes moving around in it. Nothing too fancy.
+         function Widget() {
+            // Create a tween group for the two tween chains.
+            
+            this.domElement = document.createElement("div");
+            this.domElement.className = "Widget";
+            
+            // Create the box that starts in the top left of the widget
+            var _box1 = new Box();
+            _box1.x = 25;
+            _box1.y = 25;
+            _box1.position();
+            this.domElement.appendChild(_box1.domElement);
+            
+            // Use this Widget object as the group key.
+            var _box1_right = new TWEEN.Tween(_box1, this)
+               .to({x:125, y:25})
+               .onUpdate(_box1.position);
+            var _box1_down = new TWEEN.Tween(_box1, this)
+               .to({x:125, y:125})
+               .onUpdate(_box1.position);
+            var _box1_left = new TWEEN.Tween(_box1, this)
+               .to({x:25, y:125})
+               .onUpdate(_box1.position);
+            var _box1_up = new TWEEN.Tween(_box1, this)
+               .to({x:25, y:25})
+               .onUpdate(_box1.position);
+            
+            // Set up the tweens in a chain loop
+            _box1_right.chain(_box1_down);
+            _box1_down.chain(_box1_left);
+            _box1_left.chain(_box1_up);
+            _box1_up.chain(_box1_right);
+            
+            // Start with a rightward motion
+            _box1_right.start();
+            
+            // Create the box that starts in the bottom right of the widget
+            var _box2 = new Box();
+            _box2.x = 125;
+            _box2.y = 125;
+            _box2.position();
+            this.domElement.appendChild(_box2.domElement);
+            var _box2_right = new TWEEN.Tween(_box2, this)
+               .to({x:125, y:25})
+               .onUpdate(_box2.position);
+            var _box2_down = new TWEEN.Tween(_box2, this)
+               .to({x:125, y:125})
+               .onUpdate(_box2.position);
+            var _box2_left = new TWEEN.Tween(_box2, this)
+               .to({x:25, y:125})
+               .onUpdate(_box2.position);
+            var _box2_up = new TWEEN.Tween(_box2, this)
+               .to({x:25, y:25})
+               .onUpdate(_box2.position);
+            _box2_right.chain(_box2_down);
+            _box2_down.chain(_box2_left);
+            _box2_left.chain(_box2_up);
+            _box2_up.chain(_box2_right);
+            _box2_left.start();
+            
+            // The rest of the code in this class has to do with pausing.
+            
+            var _paused = false;
+            var _lastAnimationRequestID = undefined;
+            var _pauseStartTime;
+            var _totalPausedTime = 0;
+            
+            var thisWidget = this;
+            this.animate = (function(time) {
+               TWEEN.update(time - _totalPausedTime, thisWidget);
+               _lastAnimationTime = time;
+               _lastAnimationRequestID = requestAnimationFrame(this.animate);
+            }).bind(this);
+            
+            this.togglePaused = (function() {
+               if (_paused) {
+                  _lastAnimationRequestID = requestAnimationFrame(this.animate);
+                  _paused = false;
+                  _totalPausedTime += performance.now() - _pauseStartTime;
+               } else {
+                  if (_lastAnimationRequestID) {
+                     cancelAnimationFrame(_lastAnimationRequestID);
+                     _lastAnimationRequestID = undefined;
+                  }
+                  _paused = true;
+                  _pauseStartTime = performance.now();
+               }
+            }).bind(this);
+            
+            this.domElement.onclick = this.togglePaused;
+            
+            // Allow this widget to be garbage collected.
+            this.destroy = function() {
+               // Force the animation loop to stop.
+               if (_lastAnimationRequestID) {
+                  cancelAnimationFrame(_lastAnimationRequestID);
+               }
+            };
+         }
+         
+         var add = document.getElementById("add");
+         var remove = document.getElementById("remove");
+         
+         var widgetContainer = document.getElementById("widgetContainer");
+         
+         var widgets = [];
+         
+         // When the user clicks the "Add Widget" button, create a widget and append its
+         // domElement to the end of the container element.
+         add.onclick = function() {
+            var widget = new Widget();
+            widgets.push(widget);
+            widgetContainer.appendChild(widget.domElement);
+            widget.animate()
+         };
+         
+         // If there are any widgets left, remove the last one and destroy it.
+         remove.onclick = function() {
+            var removedWidget = widgets.pop();
+            if (removedWidget) {
+               widgetContainer.removeChild(removedWidget.domElement);
+               removedWidget.destroy();
+            }
+         };
+      </script>
+
+      <style type="text/css">
+         .Box {
+            width: 50px;
+            height: 50px;
+            display: block;
+            -webkit-border-radius: 10px;
+            -moz-border-radius: 10px;
+            border-radius: 10px;
+            position: absolute;
+            background-color: #222;
+         }
+
+         .Widget {
+            width: 200px;
+            height: 200px;
+            margin: -1px -1px 0px 0px;
+            float: left;
+            position: relative;
+            border: 1px solid black;
+            background-color: #CCC;
+         }
+      </style>
+   </body>
+</html>

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -33,6 +33,7 @@
 var TWEEN = TWEEN || (function () {
 
 	var _tweens = {};
+   tweens[undefined] = [];
 
 	return {
 
@@ -67,7 +68,7 @@ var TWEEN = TWEEN || (function () {
                _tweens[group].splice(i, 1);
             }
             
-            if (_tweens[group].length === 0) {
+            if (_tweens[group].length === 0 && group !== undefined) {
                delete _tweens[group];
             }
          }

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -105,7 +105,7 @@ var TWEEN = TWEEN || (function () {
 
 })();
 
-TWEEN.Tween = function (object) {
+TWEEN.Tween = function (object, group) {
 
 	var _object = object;
 	var _valuesStart = {};
@@ -146,7 +146,7 @@ TWEEN.Tween = function (object) {
 
 	this.start = function (time) {
 
-		TWEEN.add(this);
+		TWEEN.add(this, group);
 
 		_isPlaying = true;
 
@@ -189,7 +189,7 @@ TWEEN.Tween = function (object) {
 			return this;
 		}
 
-		TWEEN.remove(this);
+		TWEEN.remove(this, group);
 		_isPlaying = false;
 
 		if (_onStopCallback !== null) {

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -46,6 +46,7 @@ var TWEEN = TWEEN || (function () {
 		removeAll: function () {
 
 			_tweens = {};
+         _tweens[undefined] = [];
 
 		},
 

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -32,59 +32,73 @@
 
 var TWEEN = TWEEN || (function () {
 
-	var _tweens = [];
+	var _tweens = {};
 
 	return {
 
 		getAll: function () {
 
-			return _tweens;
+			return _tweens[undefined];
 
 		},
 
 		removeAll: function () {
 
-			_tweens = [];
+			_tweens = {};
 
 		},
 
-		add: function (tween) {
-
-			_tweens.push(tween);
-
-		},
-
-		remove: function (tween) {
-
-			var i = _tweens.indexOf(tween);
-
-			if (i !== -1) {
-				_tweens.splice(i, 1);
-			}
+		add: function (tween, group) {
+      
+         if (_tweens[group] === undefined) {
+            _tweens[group] = [];
+         }
+         
+			_tweens[group].push(tween);
 
 		},
 
-		update: function (time) {
+		remove: function (tween, group) {
 
-			if (_tweens.length === 0) {
-				return false;
-			}
+         if (_tweens[group]) {
+            var i = _tweens[group].indexOf(tween);
 
-			var i = 0;
+            if (i !== -1) {
+               _tweens[group].splice(i, 1);
+            }
+            
+            if (_tweens[group].length === 0) {
+               delete _tweens[group];
+            }
+         }
 
-			time = time !== undefined ? time : window.performance.now();
+		},
 
-			while (i < _tweens.length) {
+		update: function (time, group) {
+         
+         if (_tweens[group] !== undefined) {
+            if (_tweens[group].length === 0) {
+               return false;
+            }
 
-				if (_tweens[i].update(time)) {
-					i++;
-				} else {
-					_tweens.splice(i, 1);
-				}
+            var i = 0;
 
-			}
+            time = time !== undefined ? time : window.performance.now();
 
-			return true;
+            while (i < _tweens[group].length) {
+
+               if (_tweens[group][i].update(time)) {
+                  i++;
+               } else {
+                  _tweens[group].splice(i, 1);
+               }
+
+            }
+
+            return true;
+         } else {
+            return false;
+         }
 
 		}
 	};

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -33,7 +33,7 @@
 var TWEEN = TWEEN || (function () {
 
 	var _tweens = {};
-   tweens[undefined] = [];
+   _tweens[undefined] = [];
 
 	return {
 

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -863,6 +863,82 @@
 
 			},
 
+         'Test that groups animate separately': function(test) {
+         
+            var obj1 = { x: 0 };
+            var obj2 = { x: 0 };
+            var obj3 = { x: 0 };
+            
+            var tween1 = new TWEEN.Tween(obj1, 'group1').to({x: 10}, 10).start(0);
+            var tween2 = new TWEEN.Tween(obj2, 'group1').to({x: 20}, 10).start(0);
+            
+            var tween3 = new TWEEN.Tween(obj3, 'group2').to({x: 10}, 10).start(0);
+            
+            test.equal(obj1.x, 0);
+            test.equal(obj2.x, 0);
+            test.equal(obj3.x, 0);
+            
+            TWEEN.update(5, 'group1');
+            
+            test.equal(obj1.x, 5);
+            test.equal(obj2.x, 10);
+            test.equal(obj3.x, 0);
+            
+            TWEEN.update(10, 'group2');
+            
+            test.equal(obj1.x, 5);
+            test.equal(obj2.x, 10);
+            test.equal(obj3.x, 10);
+            
+            TWEEN.update(10, 'group1');
+            
+            test.equal(obj1.x, 10);
+            test.equal(obj2.x, 20);
+            test.equal(obj3.x, 10);
+         
+            test.done();
+         
+         },
+         
+         'Test that tweens can be removed from groups': function(test) {
+            var obj1 = { x: 0 };
+            var obj2 = { x: 0 };
+            var obj3 = { x: 0 };
+            
+            var tween1 = new TWEEN.Tween(obj1, 'group1').to({x: 10}, 10).start(0);
+            var tween2 = new TWEEN.Tween(obj2, 'group1').to({x: 20}, 10).start(0);
+            
+            var tween3 = new TWEEN.Tween(obj3, 'group2').to({x: 10}, 10).start(0);
+            
+            test.equal(obj1.x, 0);
+            test.equal(obj2.x, 0);
+            test.equal(obj3.x, 0);
+            
+            TWEEN.update(5, 'group1');
+            
+            test.equal(obj1.x, 5);
+            test.equal(obj2.x, 10);
+            test.equal(obj3.x, 0);
+            
+            TWEEN.remove(tween2, 'group1');
+            
+            TWEEN.update(10, 'group2');
+            
+            test.equal(obj1.x, 5);
+            test.equal(obj2.x, 10);
+            test.equal(obj3.x, 10);
+            
+            TWEEN.update(10, 'group1');
+            
+            test.equal(obj1.x, 10);
+            test.equal(obj2.x, 10);
+            test.equal(obj3.x, 10);
+            
+            test.done();
+            
+         },
+         
+         
 		};
 
 		return tests;


### PR DESCRIPTION
Hi again. This is another attempt at adding group functionality. It is fully backwards compatible as before. This time there is no group class. Instead, the add, remove, and update functions, as well as the TWEEN.Tween constructor now accept an additional group key as a parameter. If omitted, the group key is naturally undefined, so the default group uses the undefined key. That's all there is to it. It may be a little awkward that the remove function requires the group, but that can be changed easily so that it checks all of the groups instead. It could also be moved into the constructor so that it could reference the group variable through closure. Also note that when emptied, all groups except the default group are deleted. Ensuring that empty groups are deleted prevents memory leaks.
