### PR TITLE
Don't add tween to root object if root is undefined

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -864,7 +864,7 @@ TWEEN.Interpolation = {
 		// Node.js
 		module.exports = TWEEN;
 
-	} else {
+	} else if(root !== undefined) {
 
 		// Global variable
 		root.TWEEN = TWEEN;

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -864,7 +864,7 @@ TWEEN.Interpolation = {
 		// Node.js
 		module.exports = TWEEN;
 
-	} else if(root !== undefined) {
+	} else if (root !== undefined) {
 
 		// Global variable
 		root.TWEEN = TWEEN;


### PR DESCRIPTION
In our build environment we force strict mode, leading to an undefined "root". This PR adds an undefined check so we don't get console errors.