### PR TITLE
Fix bug about "module is not defined"

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -859,7 +859,7 @@ TWEEN.Interpolation = {
 			return TWEEN;
 		});
 
-	} else if (typeof exports === 'object') {
+	} else if (typeof module !== 'undefined' && typeof exports === 'object') {
 
 		// Node.js
 		module.exports = TWEEN;


### PR DESCRIPTION
In some environments , there may be a global object named exports. 
for example, some code maybe do this :
```
var exports = exports || window;
```

So ,  I think check module & exports both is a better way.