### PR TITLE
Scoped window object to 'this'

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -8,7 +8,7 @@
  */
 
 // Include a performance.now polyfill
-(function () {
+(function (window) {
 
 	if ('performance' in window === false) {
 		window.performance = {};
@@ -28,7 +28,7 @@
 		};
 	}
 
-})();
+})(this);
 
 var TWEEN = TWEEN || (function () {
 


### PR DESCRIPTION
In a nodejs environment, `window` is undefined. The fix scopes the
performance.now polyfill to `this`, being `process` on node and `window` in
the browser.

This is used for isomorphic projects - JS written to run on nodejs and browser.