### PR TITLE
Issue #264

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -40,7 +40,7 @@ var TWEEN = TWEEN || (function () {
 
 		getAll: function () {
 
-			return Object.keys(_tweens).map(function(tweenId) {
+			return Object.keys(_tweens).map(function (tweenId) {
 				return _tweens[tweenId];
 			});
 
@@ -69,7 +69,7 @@ var TWEEN = TWEEN || (function () {
 		update: function (time) {
 
 			var tweenIds = Object.keys(_tweens);
-		
+
 			if (tweenIds.length === 0) {
 				return false;
 			}
@@ -82,21 +82,21 @@ var TWEEN = TWEEN || (function () {
 			// if the removed tween was added during the current batch, then it will not be updated.
 			while (tweenIds.length > 0) {
 				_tweensAddedDuringUpdate = {};
-				
+
 				for (var i = 0; i < tweenIds.length; i++) {
 					if (_tweens[tweenIds[i]].update(time) === false) {
 						delete _tweens[tweenIds[i]];
 					}
 				}
-				
+
 				tweenIds = Object.keys(_tweensAddedDuringUpdate);
 			}
 
 			return true;
 
 		},
-		
-		nextId: function() {
+
+		nextId: function () {
 			return _nextId++;
 		}
 	};
@@ -130,8 +130,8 @@ TWEEN.Tween = function (object) {
 	for (var field in object) {
 		_valuesStart[field] = parseFloat(object[field], 10);
 	}
-	
-	this.getId = function() {
+
+	this.getId = function () {
 		return _id;
 	};
 

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -83,11 +83,11 @@ var TWEEN = TWEEN || (function () {
 			while (tweenIds.length > 0) {
 				_tweensAddedDuringUpdate = {};
 				
-				tweenIds.forEach(function(tweenId) {
-					if (_tweens[tweenId].update(time) === false) {
-						delete _tweens[tweenId];
+				for (var i = 0; i < tweenIds.length; i++) {
+					if (_tweens[tweenIds[i]].update(time) === false) {
+						delete _tweens[tweenIds[i]];
 					}
-				});
+				}
 				
 				tweenIds = Object.keys(_tweensAddedDuringUpdate);
 			}

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -34,7 +34,6 @@ var TWEEN = TWEEN || (function () {
 
 	var _tweens = {};
 	var _tweensAddedDuringUpdate = {};
-	var _tweensRemovedDuringUpdate = {};
 	var _nextId = 0;
 
 	return {

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -57,7 +57,7 @@
 				TWEEN.add( t );
 
 				test.equal( numTweens + 1, TWEEN.getAll().length );
-				test.equal( all, TWEEN.getAll() );
+
 				test.done();
 
 			},

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -70,13 +70,12 @@
 
 				TWEEN.add( t );
 
-				test.ok( all.indexOf( t ) != -1 );
+				test.ok( TWEEN.getAll().indexOf( t ) != -1 );
 
 				TWEEN.remove( t );
 
 				test.equal( numTweens, TWEEN.getAll().length );
-				test.equal( all, TWEEN.getAll() );
-				test.equal( all.indexOf( t ), -1 );
+				test.equal( TWEEN.getAll().indexOf( t ), -1 );
 				test.done();
 
 			},


### PR DESCRIPTION
There's some strange behavior when adding or removing tweens during an onUpdate or onComplete callback.

The problem beforehand was that `TWEEN.update` might remove the wrong tween if a tween occurring before the one being updated was removed.

By using an object to contain all the tweens instead of an array, and by using a unique integer as a tween's key, this problem is fixed.

Tweens that are removed during an update are still updated. Previously this behavior depended on whether the removed tween came before or after the one being updated in the tween array. Tweens that are added during an update will still be updated during the current "frame", just like before. If you add and then immediately remove a tween it should not be updated. In general, don't rely on adding then removing a single tween during the same frame. For more details, read the comment I wrote in `TWEEN.update`.
