### PR TITLE
Replaced unsupported `startsWith` String method on IE that breaks compatibility

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -316,7 +316,7 @@ TWEEN.Tween = function (object) {
 				// Parses relative end values with start as base (e.g.: +10, -3)
 				if (typeof (end) === 'string') {
 
-					if (end.startsWith('+') || end.startsWith('-')) {
+					if (end.charAt(0) === '+' || end.charAt(0) === '-') {
 						end = start + parseFloat(end, 10);
 					} else {
 						end = parseFloat(end, 10);


### PR DESCRIPTION
The `startsWith` String method is not implemented in Internet Explorer and though breaks the entire library. Reference here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith

