### PR TITLE
Add an 'end' function.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -203,12 +203,12 @@ TWEEN.Tween = function (object) {
 		return this;
 
 	};
-	
+
 	this.end = function () {
-	  
-		this.update(_duration);
+
+		this.update(_startTime + _duration);
 		return this;
-		
+
 	};
 
 	this.stopChainedTweens = function () {

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -959,6 +959,51 @@
 				test.done();
 
 			},
+			
+			'Test that TWEEN.Tween.end sets the final values.': function(test) {
+
+				var object1 = {x: 0, y: -50, z: 1000};
+				var target1 = {x: 50, y: 123, z: '+234'};
+
+				var tween1 = new TWEEN.Tween(object1).to(target1, 1000);
+
+				tween1.start();
+				tween1.end();
+
+				test.equal(object1.x, 50);
+				test.equal(object1.y, 123);
+				test.equal(object1.z, 1234);
+
+				var object2 = {x: 0, y: -50, z: 1000};
+				var target2 = {x: 50, y: 123, z: '+234'};
+
+				var tween2 = new TWEEN.Tween(object2).to(target2, 1000);
+
+				tween2.start(300);
+				tween2.update(500);
+				tween2.end();
+
+				test.equal(object2.x, 50);
+				test.equal(object2.y, 123);
+				test.equal(object2.z, 1234);
+
+				test.done();
+			},
+
+			'Test that TWEEN.Tween.end calls the onComplete callback of the tween.': function(test) {
+
+				test.expect(1);
+
+				var tween1 = new TWEEN.Tween({}).to({}, 1000).onComplete(function () {
+					test.ok(true);
+				});
+
+				tween1.start();
+				tween1.end();
+
+				test.done();
+
+			},
 
 		};
 


### PR DESCRIPTION
Add an 'end' function that causes a tween to immediately finish, setting all of the final values on the target object.