### PR TITLE
remove "this" in front of window.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -72,7 +72,7 @@ var TWEEN = TWEEN || (function () {
 // Include a performance.now polyfill
 (function () {
 	// In node.js, use process.hrtime.
-	if (this.window === undefined && this.process !== undefined) {
+	if (window === undefined && this.process !== undefined) {
 		TWEEN.now = function () {
 			var time = process.hrtime();
 
@@ -81,7 +81,7 @@ var TWEEN = TWEEN || (function () {
 		};
 	}
 	// In a browser, use window.performance.now if it is available.
-	else if (this.window !== undefined &&
+	else if (window !== undefined &&
 	         window.performance !== undefined &&
 		 window.performance.now !== undefined) {
 


### PR DESCRIPTION
Hello! I noticed this broke your tweening library. window isn't an object of "this" and so if you remove the "this" in front of window, it should fix the library. Thanks for your consideration!