### PR TITLE
Object.defineProperty compatibility

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -169,7 +169,7 @@ TWEEN.Tween = function (object) {
 
 			// If `to()` specifies a property that doesn't exist in the source object,
 			// we should not set that property in the object
-			if (_valuesStart[property] === undefined) {
+			if (_object[property] === undefined) {
 				continue;
 			}
 

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1,7 +1,7 @@
 (function() {
 
 	function getTests(TWEEN) {
-		
+
 		var tests = {
 			'hello': function(test) {
 				test.ok(TWEEN !== null);
@@ -158,25 +158,25 @@
 				test.ok( TWEEN.getAll().indexOf( t2 ) != -1 );
 				test.done();
 			},
-			
-			
+
+
 			'Unremoved tweens which have been updated past their finish time may be reused': function(test) {
 
 				TWEEN.removeAll();
 
 				var target1 = {a:0};
 				var target2 = {b:0};
-				
+
 				var t1 = new TWEEN.Tween( target1 ).to( {a:1}, 1000 ),
 					t2 = new TWEEN.Tween( target2 ).to( {b:1}, 2000 );
 
 				t1.start( 0 );
 				t2.start( 0 );
-				
+
 				TWEEN.update(200, true);
 				TWEEN.update(2500, true);
 				TWEEN.update(500, true);
-				
+
 				test.equal(TWEEN.getAll().length, 2);
 				test.equal(target1.a, 0.5);
 				test.equal(target2.b, 0.25);
@@ -226,7 +226,7 @@
 
 				test.ok( t.onStop() instanceof TWEEN.Tween );
 				test.equal( t.onStop(), t );
-				
+
 				test.ok( t.onUpdate() instanceof TWEEN.Tween );
 				test.equal( t.onUpdate(), t );
 
@@ -930,7 +930,7 @@
 				t.start( 0 );
 				TWEEN.update( 1001 );
 				t.stop();
-				
+
 				test.equal( tStarted, true );
 				test.equal( t2Started, false );
 				test.equal( TWEEN.getAll().length, 0 );
@@ -959,7 +959,7 @@
 				test.done();
 
 			},
-			
+
 			'Test that TWEEN.Tween.end sets the final values.': function(test) {
 
 				var object1 = {x: 0, y: -50, z: 1000};
@@ -1009,7 +1009,7 @@
 
 				// If repeatDelay isn't specified then delay is used since
 				// that's the way it worked before repeatDelay was added.
-			
+
 				TWEEN.removeAll();
 
 				var obj = { x: 0 },
@@ -1059,7 +1059,7 @@
 
 				TWEEN.update( 100 );
 				test.equal( obj.x, 100 );
-				
+
 				TWEEN.update( 200 );
 				test.equal( obj.x, 100 );
 
@@ -1108,6 +1108,30 @@
 
 				test.done();
 
+			},
+
+			'Tween.js compatible with Object.defineProperty getter / setters': function(test) {
+
+				var obj = { _x: 0 };
+
+				Object.defineProperty( obj, 'x', {
+					get: function() {
+						return this._x;
+					},
+					set: function( x ) {
+						this._x = x;
+					}
+				});
+
+				var t = new TWEEN.Tween( obj ).to( { x: 100 }, 100 );
+
+				t.start( 0 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.x, 100 );
+
+				test.done();
+
 			}
 
 		};
@@ -1121,5 +1145,5 @@
 	} else {
 		this.getTests = getTests;
 	}
-	
+
 }).call(this);


### PR DESCRIPTION
I love using Tween.js. It's in almost all of my projects like [Patatap](http://patatap.com) to client work like this illustration for [the New Yorker](http://www.newyorker.com/magazine/2015/11/23/doomsday-invention-artificial-intelligence-nick-bostrom). For many of my projects I use a library I created and maintain, [Two.js](http://jonobr1.github.io/two.js). Recently, the two libraries don't seem to be compatible... So, I started to do some digging:

The current version of `Tween.js` isn't compatible with any form of `Object.defineProperty` getter / setters. I modified the `start` method to be compatible with this ES5 paradigm. Consequently, Two.js relies on this paradigm a lot. The line I modified checks `_valuesStart[property] === undefined` which doesn't exist for getter / setters because it's a "function" underneath. However, if you check it on the `_object` instead of `_valuesStart` then it exists. Also, from inferring a few lines down you set `_valuesStart[property] = _object[property]` _anyway_, so I hope  this modification doesn't disrupt other use cases. As per the contribution guidelines I tested all the `/tests` and `/examples` as well as added a test to make sure this wouldn't break in the future.

Hopefully you consider this PR. At the very least, I hope this sparks discussion so that we can make Tween.js compatible with `Object.defineProperty` and libraries like `Two.js` 👍 