### PR TITLE
Fix: TWEEN.now() returns broken timestamp in node.js.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -76,8 +76,8 @@ var TWEEN = TWEEN || (function () {
 		TWEEN.now = function () {
 			var time = process.hrtime();
 
-			// Convert [seconds, microseconds] to milliseconds.
-			return time[0] * 1000 + time[1] / 1000;
+			// Convert [seconds, nanoseconds] to milliseconds.
+			return time[0] * 1000 + time[1] / 1000000;
 		};
 	}
 	// In a browser, use window.performance.now if it is available.


### PR DESCRIPTION
I found a issue that a tweened value reaches the target value immediately when I use it in node.js. The root cause is that `TWEEN.now()` returns broken timestamp in node.js. Tween.js uses `process.hrtime()` to get the current timestamp but it interprets the returned in the wrong way. Please review and merge my PR.