### PR TITLE
Do not copy every field of the tweenable object, only those which are going to be tweened.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -133,13 +133,13 @@ TWEEN.Tween = function (object) {
 
 		_valuesEnd = properties;
 
-        // Set all starting values present on the target object
-        for (var field in _valuesEnd) {
-        	// only add to updateables if tweenable object has the field
-            if ( typeof _object[ field ] !== "undefined" ) {
-                _valuesStart[ field ] = parseFloat( _object[ field ], 10 );
-            }
-        }
+		// Set all starting values present on the target object
+		for (var field in _valuesEnd) {
+			// Only add to updateables if tweenable object has the field
+			if (typeof _object[field] !== 'undefined') {
+				_valuesStart[field] = parseFloat(_object[field], 10);
+			}
+		}
 
 		return this;
 

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -125,11 +125,6 @@ TWEEN.Tween = function (object) {
 	var _onCompleteCallback = null;
 	var _onStopCallback = null;
 
-	// Set all starting values present on the target object
-	for (var field in object) {
-		_valuesStart[field] = parseFloat(object[field], 10);
-	}
-
 	this.to = function (properties, duration) {
 
 		if (duration !== undefined) {
@@ -137,6 +132,14 @@ TWEEN.Tween = function (object) {
 		}
 
 		_valuesEnd = properties;
+
+        // Set all starting values present on the target object
+        for (var field in _valuesEnd) {
+        	// only add to updateables if tweenable object has the field
+            if ( typeof _object[ field ] !== "undefined" ) {
+                _valuesStart[ field ] = parseFloat( _object[ field ], 10 );
+            }
+        }
 
 		return this;
 


### PR DESCRIPTION
Adds only the values that are set in .to properties, i don't see the point why should every property be added, even if it is not going to be tweened.

It is more of a enhancement than a fix, if there is a reason why it is done like it is right now, could you explain it to me?