### PR TITLE
Wrong Conversion for Node.js polyfill for performance.now

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -76,7 +76,7 @@ if (typeof (window) === 'undefined' && typeof (process) !== 'undefined') {
 		var time = process.hrtime();
 
 		// Convert [seconds, nanoseconds] to milliseconds.
-		return time[0] * 1000 + time[1] / 1000000;
+		 return time[0] * 1e9 + time[1] / 1000000;
 	};
 }
 // In a browser, use window.performance.now if it is available.


### PR DESCRIPTION
We need to convert seconds straight to nanoseconds in order to add the second item in the array and then divide by 1e6 in order to get milliseconds. (Line: 79)