### PR TITLE
Add tween to nested object

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -364,7 +364,7 @@ The way these values are calculated is as follows:
 * the progress (from 0 to 1) is used as input for the interpolation function
 * based on the progress and the array of values, an interpolated value is generated
 
-For example, when the tween has just started (progress is 0), the interpolation function will return the first value in the array. When the tween is halfway, the interpolation function will return a value approximately in the middle of the array, and when the tween is at the end, the interpolation function will return the last value. 
+For example, when the tween has just started (progress is 0), the interpolation function will return the first value in the array. When the tween is halfway, the interpolation function will return a value approximately in the middle of the array, and when the tween is at the end, the interpolation function will return the last value.
 
 You can change the interpolation function with the `interpolation` method. For example:
 
@@ -383,6 +383,16 @@ The default is `Linear`.
 Note that the interpolation function is global to all properties that are tweened with arrays in the same tween. You can't make property A change with an array and a Linear function, and property B with an array too and a Bezier function using the same tween; you should use two tween objects running over the same object but modifying different properties and using different interpolation functions.
 
 Check [06_array_interpolation](../examples/06_array_interpolation.html) for an example.
+
+### Tweening nested object
+
+Tween.js can also change properties across nested object, to do this you just need to use a string path pointing to the properties. For example:
+
+```javascript
+var nestedObject = { scale: { x:0, y:0 } }
+
+var tween = new TWEEN.Tween(nestedObject).to({ 'scale.x': 100, 'scale.y': 100 });
+```
 
 ## Getting the best performance
 

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1123,26 +1123,107 @@
 					}
 				});
 
-                test.equal( obj.x, 0 );
+				test.equal( obj.x, 0 );
 
 				var t = new TWEEN.Tween( obj ).to( { x: 100 }, 100 );
 
 				t.start( 0 );
 
-                test.equal( obj.x, 0 );
+				test.equal( obj.x, 0 );
 
-                TWEEN.update( 37 );
-                test.equal( obj.x, 37 );
+				TWEEN.update( 37 );
+				test.equal( obj.x, 37 );
 
 				TWEEN.update( 100 );
 				test.equal( obj.x, 100 );
 
-                TWEEN.update( 115 );
-                test.equal( obj.x, 100 );
+				TWEEN.update( 115 );
+				test.equal( obj.x, 100 );
 
 				test.done();
 
-			}
+			},
+
+			'Tween.js animate nested object': function(test) {
+
+				var obj = { scale: { x: 0 } };
+
+				var t = new TWEEN.Tween( obj ).to( { 'scale.x': 100 }, 100 );
+				t.start( 0 );
+
+				test.equal( obj.scale.x, 0 );
+
+				TWEEN.update( 37 );
+				test.equal( obj.scale.x, 37 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.scale.x, 100 );
+
+				TWEEN.update( 115 );
+				test.equal( obj.scale.x, 100 );
+
+				test.done();
+
+			},
+
+
+			'Tween.js animate complex nested object': function(test) {
+
+				var obj = { world: { hero: { scale: { x: 0 }, x: 100 } }, time: 0 };
+
+				var t = new TWEEN
+					.Tween( obj )
+					.to( {
+						'world.hero.scale.x': 100,
+						'world.hero.x': '+100',
+						'time': 100,
+					}, 100 );
+				t.start( 0 );
+
+				test.equal( obj.world.hero.scale.x, 0 );
+
+				TWEEN.update( 37 );
+				test.equal( obj.world.hero.scale.x, 37 );
+				test.equal( obj.world.hero.x, 137 );
+				test.equal( obj.time, 37 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.world.hero.scale.x, 100 );
+				test.equal( obj.world.hero.x, 200 );
+				test.equal( obj.time, 100 );
+
+				TWEEN.update( 115 );
+				test.equal( obj.world.hero.scale.x, 100 );
+				test.equal( obj.world.hero.x, 200 );
+				test.equal( obj.time, 100 );
+
+				test.done();
+
+			},
+
+			'Tween.js protect worg path in nested object': function(test) {
+
+				var obj = { world: { hero: { scale: { x: 0 } } } };
+
+				var t = new TWEEN.Tween( obj ).to( { 'world.x': 100 }, 100 );
+				t.start( 0 );
+
+				test.equal( obj.world.hero.scale.x, 0 );
+
+				TWEEN.update( 37 );
+				test.equal( obj.world.hero.scale.x, 0 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.world.hero.scale.x, 0 );
+
+				TWEEN.update( 115 );
+				test.equal( obj.world.hero.scale.x, 0 );
+
+				test.equal( obj.world.x, undefined );
+
+				test.done();
+
+			},
 
 		};
 

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1201,7 +1201,7 @@
 
 			},
 
-			'Tween.js protect worg path in nested object': function(test) {
+			'Tween.js protect wrong path in nested object': function(test) {
 
 				var obj = { world: { hero: { scale: { x: 0 } } } };
 
@@ -1220,6 +1220,72 @@
 				test.equal( obj.world.hero.scale.x, 0 );
 
 				test.equal( obj.world.x, undefined );
+
+				test.done();
+
+			},
+
+			'Tween.js animation flat property with array': function(test) {
+
+				var obj = { scale: { x: 0 } };
+
+				var t = new TWEEN.Tween( obj ).to( { 'scale.x': [ 50, 100 ] }, 100 );
+				t.start( 0 );
+
+				test.equal( obj.scale.x, 0 );
+
+				TWEEN.update( 37 );
+				test.equal( obj.scale.x, 37 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.scale.x, 100 );
+
+				TWEEN.update( 115 );
+				test.equal( obj.scale.x, 100 );
+
+				test.done();
+
+			},
+
+			'Tween.js animation flat property with array and relative values': function(test) {
+
+				var obj = { scale: { x: 100 } };
+
+				var t = new TWEEN.Tween( obj ).to( { 'scale.x': [ '+50', '+100' ] }, 100 );
+				t.start( 0 );
+
+				test.equal( obj.scale.x, 100 );
+
+				TWEEN.update( 37 );
+				test.equal( obj.scale.x, 137 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.scale.x, 200 );
+
+				TWEEN.update( 115 );
+				test.equal( obj.scale.x, 200 );
+
+				test.done();
+
+			},
+
+			'Tween.js animation with array and relative values': function(test) {
+
+				var obj = { x: 100 };
+
+				var t = new TWEEN.Tween( obj ).to( { x: [ '+50', '+100' ] }, 100 );
+				t.start( 0 );
+
+				test.equal( obj.x, 100 );
+
+				TWEEN.update( 37 );
+				test.equal( obj.x, 137 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.x, 200 );
+
+				TWEEN.update( 115 );
+				test.equal( obj.x, 200 );
 
 				test.done();
 


### PR DESCRIPTION
Hi there !

In reaction to this issues  #52 #78, I sugest this simple API :

With this PR Tween.js can now change properties across nested object, to do this you just need to use a string path pointing to the properties. For example:

```javascript
var nestedObject = { scale: { x:0, y:0 } }

var tween = new TWEEN.Tween(nestedObject).to({ 'scale.x': 100, 'scale.y': 100 });
```

This PR includes UnitTests and Documentation.

I'm open to any sugestion.