### PR TITLE
chore: add a simple babel build step

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+      "env"
+  ],
+  "plugins": [
+      "transform-es2015-modules-umd"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/npm*
 node_modules
 npm-debug.log
+dist

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.0",
+    "babel-preset-env": "^1.2.2",
     "jscs": "^2.2.0",
     "jshint": "^2.8.0",
     "nodeunit": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tween.js",
   "description": "Super simple, fast and easy to use tweening engine which incorporates optimised Robert Penner's equations.",
   "version": "0.0.0-development",
-  "main": "src/Tween.js",
+  "main": "dist/TWEEN.js",
   "homepage": "https://github.com/tweenjs/tween.js",
   "repository": {
     "type": "git",
@@ -18,14 +18,18 @@
   ],
   "dependencies": {},
   "scripts": {
-    "test": "npm run test-unit && npm run test-correctness && npm run test-style",
+    "test": "npm run build && npm run test-unit && npm run test-correctness && npm run test-style",
     "test-unit": "nodeunit test/unit/nodeunitheadless.js",
-    "test-correctness": "jshint --config test/jshintrc src/Tween.js",
-    "test-style": "jscs --config test/jscs.json src/Tween.js",
+    "test-correctness": "jshint --config test/jshintrc src/TWEEN.js",
+    "test-style": "jscs --config test/jscs.json src/TWEEN.js",
+    "build": "babel src --out-dir dist",
+    "prepublish": "npm run test",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "author": "tween.js contributors (https://github.com/tweenjs/tween.js/graphs/contributors)",
   "devDependencies": {
+    "babel-cli": "^6.24.0",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.0",
     "jscs": "^2.2.0",
     "jshint": "^2.8.0",
     "nodeunit": "^0.9.1",

--- a/src/TWEEN.js
+++ b/src/TWEEN.js
@@ -7,9 +7,9 @@
  * Thank you all, you're awesome!
  */
 
-var TWEEN = TWEEN || (function () {
+const TWEEN = (function () {
 
-	var _tweens = [];
+	let _tweens = [];
 
 	return {
 
@@ -33,7 +33,7 @@ var TWEEN = TWEEN || (function () {
 
 		remove: function (tween) {
 
-			var i = _tweens.indexOf(tween);
+			const i = _tweens.indexOf(tween);
 
 			if (i !== -1) {
 				_tweens.splice(i, 1);
@@ -47,7 +47,7 @@ var TWEEN = TWEEN || (function () {
 				return false;
 			}
 
-			var i = 0;
+			let i = 0;
 
 			time = time !== undefined ? time : TWEEN.now();
 
@@ -73,7 +73,7 @@ var TWEEN = TWEEN || (function () {
 // In node.js, use process.hrtime.
 if (typeof (window) === 'undefined' && typeof (process) !== 'undefined') {
 	TWEEN.now = function () {
-		var time = process.hrtime();
+		const time = process.hrtime();
 
 		// Convert [seconds, nanoseconds] to milliseconds.
 		return time[0] * 1000 + time[1] / 1000000;
@@ -857,26 +857,4 @@ TWEEN.Interpolation = {
 
 };
 
-// UMD (Universal Module Definition)
-(function (root) {
-
-	if (typeof define === 'function' && define.amd) {
-
-		// AMD
-		define([], function () {
-			return TWEEN;
-		});
-
-	} else if (typeof module !== 'undefined' && typeof exports === 'object') {
-
-		// Node.js
-		module.exports = TWEEN;
-
-	} else if (root !== undefined) {
-
-		// Global variable
-		root.TWEEN = TWEEN;
-
-	}
-
-})(this);
+module.exports = TWEEN;

--- a/test/jshintrc
+++ b/test/jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "node": true,
   "browser": true,
   "curly": true,

--- a/test/unit/nodeunitheadless.js
+++ b/test/unit/nodeunitheadless.js
@@ -1,5 +1,5 @@
 // We will unit test both the original library and the minified version
-var TWEEN_uncompressed = require('../../src/Tween.js');
+var TWEEN_uncompressed = require('../../dist/TWEEN.js');
 var getTests = require('./tests');
 
 module.exports = {


### PR DESCRIPTION
Notes:

- Source code currently remains mostly entirely the same, but replaced some `var`s with `let` or `const` to show that it is transpiled.
- babel transpiles to `dist` folder.
- Removed manually written UMD module footer, babel creates it now, we just `module.exports = TWEEN`.
- Renamed `src/Tween.js` to `src/TWEEN.js` because babel's UMD output automatically sets the global to be named after the file name, so a filename of `Tween.js` means babel does `global.Tween = mod.exports`, while a filename of `TWEEN.js` makes babel do `global.TWEEN = mod.exports`.
- The `test` script runs the `build` script first, and runs unit tests against `dist/TWEEN.js`. jshint and jscs still run against `src/TWEEN.js`.
- The result still runs in whatever browsers were previously supported, because the output is currently the same (minus simple reformatting that babel does).

This is a small step towards updating to a modern code base while still supporting older browsers.