### PR TITLE
Update tweens in reverse. Fixes #264.

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -47,16 +47,18 @@ var TWEEN = TWEEN || (function () {
 				return false;
 			}
 
-			var i = 0;
+			var i = _tweens.length;
 
 			time = time !== undefined ? time : TWEEN.now();
 
-			while (i < _tweens.length) {
+			while (i--) {
 
-				if (_tweens[i].update(time) || preserve) {
-					i++;
-				} else {
-					_tweens.splice(i, 1);
+				var tween = _tweens[i];
+
+				if (!tween.update(time) && !preserve) {
+					if (_tweens.indexOf(tween) !== -1) {
+						_tweens.splice(i, 1);
+					}
 				}
 
 			}
@@ -67,7 +69,6 @@ var TWEEN = TWEEN || (function () {
 	};
 
 })();
-
 
 // Include a performance.now polyfill.
 // In node.js, use process.hrtime.

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -938,7 +938,7 @@
 
 			},
 
-			'Test TWEEN.Tween.chain progressess into chained tweens': function(test) {
+			'Test TWEEN.Tween.chain progresses into chained tweens': function(test) {
 
 				var obj = { t: 1000 };
 
@@ -949,6 +949,9 @@
 				var next  = new TWEEN.Tween(obj).to({ t: 2000 }, 1000);
 
 				blank.chain(next).start(0);
+
+				TWEEN.update(1000);
+				test.equal(obj.t, 1000);
 
 				TWEEN.update(1500);
 				test.equal(obj.t, 1500);
@@ -1142,8 +1145,31 @@
 
 				test.done();
 
-			}
+			},
 
+			'Test Tween.js handles removing tweens during update': function(test) {
+
+				var t1 = new TWEEN.Tween({ })
+					.to({ x: 10 }, 1000)
+					.onComplete(function() {
+						TWEEN.remove(t1);
+					})
+					.start(0);
+
+				var obj2 = { y: 0 };
+				var t2 = new TWEEN.Tween(obj2)
+					.to({ y: 10 }, 1000)
+					.start(500);
+
+				TWEEN.update(1000);
+
+				test.equal(obj2.y, 5);
+
+				test.equal(TWEEN.getAll().indexOf( t1 ), -1);
+				test.notEqual(TWEEN.getAll().indexOf( t2 ), -1);
+
+				test.done();
+			},
 		};
 
 		return tests;


### PR DESCRIPTION
This is a possible fix for handling the case where a Tween is removed during its update. 

By having TWEEN.update iterate the Tweens in reverse, a hash map is not required, unlike #266. This has the side effect that Tweens started during the current TWEEN.update (including chained tweens) won't get updated until the next TWEEN.update. This could probably be added by updating an array of `addedTweens` in TWEEN.add and processing them in TWEEN.update, but I personally don't see the need for it.

Any thoughts?