### PR TITLE
the better way to detect env is nodejs or not

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -91,7 +91,7 @@ TWEEN.nextId = function () {
 
 // Include a performance.now polyfill.
 // In node.js, use process.hrtime.
-if (typeof (window) === 'undefined' && typeof (process) !== 'undefined') {
+if (typeof (window) === 'undefined' && typeof (process) !== 'undefined' && process.hrtime) {
 	TWEEN.now = function () {
 		var time = process.hrtime();
 


### PR DESCRIPTION
Especially in webpack, we always inject a `process` object to maintain some env variables, like `process.env.NODE_ENV`, and we Chinese have some miniapp projects like wechat miniapp and alipay miniapp that we cannot access the `window` object with a `process` object in browsers.