### PR TITLE
Adds web worker capability

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -91,7 +91,7 @@ TWEEN.nextId = function () {
 
 // Include a performance.now polyfill.
 // In node.js, use process.hrtime.
-if (typeof (window) === 'undefined' && typeof (process) !== 'undefined' && process.hrtime) {
+if (typeof (self) === 'undefined' && typeof (process) !== 'undefined' && process.hrtime) {
 	TWEEN.now = function () {
 		var time = process.hrtime();
 
@@ -99,13 +99,13 @@ if (typeof (window) === 'undefined' && typeof (process) !== 'undefined' && proce
 		return time[0] * 1000 + time[1] / 1000000;
 	};
 }
-// In a browser, use window.performance.now if it is available.
-else if (typeof (window) !== 'undefined' &&
-         window.performance !== undefined &&
-		 window.performance.now !== undefined) {
+// In a browser, use self.performance.now if it is available.
+else if (typeof (self) !== 'undefined' &&
+         self.performance !== undefined &&
+		 self.performance.now !== undefined) {
 	// This must be bound, because directly assigning this function
 	// leads to an invocation exception in Chrome.
-	TWEEN.now = window.performance.now.bind(window.performance);
+	TWEEN.now = self.performance.now.bind(self.performance);
 }
 // Use Date.now if it is available.
 else if (Date.now !== undefined) {


### PR DESCRIPTION
By replacing the usage of `window` with `self`, it's possible to use this lib in web workers, e.g. very useful when rendering offscreen canvases in web workers.

https://developer.mozilla.org/en-US/docs/Web/API/Window/self