### PR TITLE
Prevent modification of the argument to to()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tweenjs/tween.js",
   "description": "Super simple, fast and easy to use tweening engine which incorporates optimised Robert Penner's equations.",
-  "version": "17.3.0",
+  "version": "17.3.1",
   "main": "src/Tween.js",
   "homepage": "https://github.com/tweenjs/tween.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tweenjs/tween.js",
   "description": "Super simple, fast and easy to use tweening engine which incorporates optimised Robert Penner's equations.",
-  "version": "17.3.1",
+  "version": "17.3.2",
   "main": "src/Tween.js",
   "homepage": "https://github.com/tweenjs/tween.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tweenjs/tween.js",
   "description": "Super simple, fast and easy to use tweening engine which incorporates optimised Robert Penner's equations.",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "main": "src/Tween.js",
   "homepage": "https://github.com/tweenjs/tween.js",
   "repository": {

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -156,7 +156,7 @@ TWEEN.Tween.prototype = {
 
 	to: function to(properties, duration) {
 
-		this._valuesEnd = properties;
+		this._valuesEnd = Object.create(properties);
 
 		if (duration !== undefined) {
 			this._duration = duration;

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1366,13 +1366,13 @@
 			function(test) {
 
 				var start = {x: 10, y: 20};
-        var end = {x: 100, y: 200, values: ['a', 'b']};
-        var valuesArray = end.values;
-        new TWEEN.Tween(start).to(end).start();
-        test.equal(valuesArray, end.values);
+				var end = {x: 100, y: 200, values: ['a', 'b']};
+				var valuesArray = end.values;
+				new TWEEN.Tween(start).to(end).start();
+				test.equal(valuesArray, end.values);
 				test.equal(end.values.length, 2);
-        test.equal(end.values[0], 'a');
-        test.equal(end.values[1], 'b');
+				test.equal(end.values[0], 'a');
+				test.equal(end.values[1], 'b');
 				test.done();
 
 			},

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1362,6 +1362,22 @@
 
 			},
 
+			'Arrays in the object passed to to() are not modified by start().':
+			function(test) {
+
+				var start = {x: 10, y: 20};
+        var end = {x: 100, y: 200, values: ['a', 'b']};
+        var valuesArray = end.values;
+        new TWEEN.Tween(start).to(end).start();
+        test.equal(valuesArray, end.values);
+				test.equal(end.values.length, 2);
+        test.equal(end.values[0], 'a');
+        test.equal(end.values[1], 'b');
+				test.done();
+
+			},
+
+
 		};
 
 		return tests;


### PR DESCRIPTION
By making _valuesEnd an empty object with the argument of to() as its prototype, we can avoid modifying that argument but still get the dynamic tweening behavior (see examples/07_dynamic_to.html)