### PR TITLE
Fix tween.end()

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -232,7 +232,7 @@ TWEEN.Tween.prototype = {
 
 	end: function end() {
 
-		this.update(this._startTime + this._duration);
+		this.update(Infinity);
 		return this;
 
 	},


### PR DESCRIPTION
Use an infinite update time to force tween.end() to result in the final
values being set on the tweened object and the onCompleteCallback being
called.