### PR TITLE
Remove faulty semicolon from user_guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -471,7 +471,7 @@ var element = document.getElementById('myElement');
 var tween = new TWEEN.Tween({ top: 0, left: 0 })
     .to({ top: 100, left: 100 }, 1000)
     .onUpdate(function(object) {
-        element.style.transform = 'translate(' + object.left + 'px, ' + object.top + 'px);';
+        element.style.transform = 'translate(' + object.left + 'px, ' + object.top + 'px)';
     });
 ```
 


### PR DESCRIPTION
Removing the faulty semicolon again, as this code just doesnt work with it. Users copy-n-paste this code and have to debug :crying_cat_face: 

See https://github.com/tweenjs/tween.js/pull/415 and this PR which re-added the semicolon: https://github.com/tweenjs/tween.js/pull/427