### PR TITLE
Replace const with var

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -1,6 +1,6 @@
 define(function () { 'use strict';
 
-	const version = '18.4.2';
+	var version = '18.4.2';
 
 	/**
 	 * Tween.js - Licensed under the MIT license

--- a/dist/tween.cjs.js
+++ b/dist/tween.cjs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const version = '18.4.2';
+var version = '18.4.2';
 
 /**
  * Tween.js - Licensed under the MIT license

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -1,4 +1,4 @@
-const version = '18.4.2';
+var version = '18.4.2';
 
 /**
  * Tween.js - Licensed under the MIT license

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -4,7 +4,7 @@
 	(global.TWEEN = factory());
 }(this, (function () { 'use strict';
 
-	const version = '18.4.2';
+	var version = '18.4.2';
 
 	/**
 	 * Tween.js - Licensed under the MIT license

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tweenjs/tween.js",
-  "version": "18.4.1",
+  "version": "18.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   ],
   "dependencies": {},
   "scripts": {
-    "build": "rollup -c ./rollup.config.js",
+    "build": "npm run write-version-js && rollup -c ./rollup.config.js && npm run remove-version-js",
     "test": "npm run build && npm run test-unit && npm run test-lint",
     "test-unit": "nodeunit test/unit/nodeunitheadless.js",
-    "test-lint": "eslint src/Tween.js"
+    "test-lint": "eslint src/Tween.js",
+	"write-version-js": "( echo -n \"export const version='\" && node -p \"require('./package.json').version\" | head -c -1 && echo \"';\" ) > ./version.js",
+	"remove-version-js": "rm ./version.js"
   },
   "author": "tween.js contributors (https://github.com/tweenjs/tween.js/graphs/contributors)",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tweenjs/tween.js",
   "description": "Super simple, fast and easy to use tweening engine which incorporates optimised Robert Penner's equations.",
-  "version": "18.4.2",
+  "version": "18.5.0",
   "main": "dist/tween.cjs.js",
   "module": "dist/tween.esm.js",
   "homepage": "https://github.com/tweenjs/tween.js",

--- a/scripts/write-version.js
+++ b/scripts/write-version.js
@@ -3,7 +3,7 @@ const {version} = require('../package.json');
 
 fs.open('.temp.version.js', 'w', (error, fd) => {
   if (error) process.exit(1);
-  fs.write(fd, `export const version = '${version}'`, (error) => {
+  fs.write(fd, `export var version = '${version}'`, (error) => {
     if (error) process.exit(1);
   });
 });

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -958,4 +958,7 @@ TWEEN.Interpolation = {
 
 };
 
+import {version} from '../version';
+TWEEN.version = version;
+
 export default TWEEN;


### PR DESCRIPTION
The "export const" statement causes Rollup to write "const" in the builds. Using "export var" instead prevents this.