### PR TITLE
Revert "Remove stopChainedTweens test because it didn't test stopChainedTweens."

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -1,6 +1,6 @@
 define(function () { 'use strict';
 
-	var version = '18.4.2';
+	var version = '18.5.0';
 
 	/**
 	 * Tween.js - Licensed under the MIT license
@@ -150,6 +150,7 @@ define(function () { 'use strict';
 		this._onStopCallback = null;
 		this._group = group || TWEEN;
 		this._id = TWEEN.nextId();
+		this._isChainStopped = false;
 
 	};
 
@@ -193,6 +194,8 @@ define(function () { 'use strict';
 
 			this._onStartCallbackFired = false;
 
+			this._isChainStopped = false;
+
 			this._startTime = time !== undefined ? typeof time === 'string' ? TWEEN.now() + parseFloat(time) : time : TWEEN.now();
 			this._startTime += this._delayTime;
 
@@ -235,6 +238,11 @@ define(function () { 'use strict';
 
 		stop: function () {
 
+			if (!this._isChainStopped) {
+				this._isChainStopped = true;
+				this.stopChainedTweens();
+			}
+
 			if (!this._isPlaying) {
 				return this;
 			}
@@ -249,7 +257,6 @@ define(function () { 'use strict';
 				this._onStopCallback(this._object);
 			}
 
-			this.stopChainedTweens();
 			return this;
 
 		},

--- a/dist/tween.cjs.js
+++ b/dist/tween.cjs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var version = '18.4.2';
+var version = '18.5.0';
 
 /**
  * Tween.js - Licensed under the MIT license
@@ -150,6 +150,7 @@ TWEEN.Tween = function (object, group) {
 	this._onStopCallback = null;
 	this._group = group || TWEEN;
 	this._id = TWEEN.nextId();
+	this._isChainStopped = false;
 
 };
 
@@ -193,6 +194,8 @@ TWEEN.Tween.prototype = {
 
 		this._onStartCallbackFired = false;
 
+		this._isChainStopped = false;
+
 		this._startTime = time !== undefined ? typeof time === 'string' ? TWEEN.now() + parseFloat(time) : time : TWEEN.now();
 		this._startTime += this._delayTime;
 
@@ -235,6 +238,11 @@ TWEEN.Tween.prototype = {
 
 	stop: function () {
 
+		if (!this._isChainStopped) {
+			this._isChainStopped = true;
+			this.stopChainedTweens();
+		}
+
 		if (!this._isPlaying) {
 			return this;
 		}
@@ -249,7 +257,6 @@ TWEEN.Tween.prototype = {
 			this._onStopCallback(this._object);
 		}
 
-		this.stopChainedTweens();
 		return this;
 
 	},

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -1,4 +1,4 @@
-var version = '18.4.2';
+var version = '18.5.0';
 
 /**
  * Tween.js - Licensed under the MIT license
@@ -148,6 +148,7 @@ TWEEN.Tween = function (object, group) {
 	this._onStopCallback = null;
 	this._group = group || TWEEN;
 	this._id = TWEEN.nextId();
+	this._isChainStopped = false;
 
 };
 
@@ -191,6 +192,8 @@ TWEEN.Tween.prototype = {
 
 		this._onStartCallbackFired = false;
 
+		this._isChainStopped = false;
+
 		this._startTime = time !== undefined ? typeof time === 'string' ? TWEEN.now() + parseFloat(time) : time : TWEEN.now();
 		this._startTime += this._delayTime;
 
@@ -233,6 +236,11 @@ TWEEN.Tween.prototype = {
 
 	stop: function () {
 
+		if (!this._isChainStopped) {
+			this._isChainStopped = true;
+			this.stopChainedTweens();
+		}
+
 		if (!this._isPlaying) {
 			return this;
 		}
@@ -247,7 +255,6 @@ TWEEN.Tween.prototype = {
 			this._onStopCallback(this._object);
 		}
 
-		this.stopChainedTweens();
 		return this;
 
 	},

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -4,7 +4,7 @@
 	(global.TWEEN = factory());
 }(this, (function () { 'use strict';
 
-	var version = '18.4.2';
+	var version = '18.5.0';
 
 	/**
 	 * Tween.js - Licensed under the MIT license
@@ -154,6 +154,7 @@
 		this._onStopCallback = null;
 		this._group = group || TWEEN;
 		this._id = TWEEN.nextId();
+		this._isChainStopped = false;
 
 	};
 
@@ -197,6 +198,8 @@
 
 			this._onStartCallbackFired = false;
 
+			this._isChainStopped = false;
+
 			this._startTime = time !== undefined ? typeof time === 'string' ? TWEEN.now() + parseFloat(time) : time : TWEEN.now();
 			this._startTime += this._delayTime;
 
@@ -239,6 +242,11 @@
 
 		stop: function () {
 
+			if (!this._isChainStopped) {
+				this._isChainStopped = true;
+				this.stopChainedTweens();
+			}
+
 			if (!this._isPlaying) {
 				return this;
 			}
@@ -253,7 +261,6 @@
 				this._onStopCallback(this._object);
 			}
 
-			this.stopChainedTweens();
 			return this;
 
 		},

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -146,6 +146,7 @@ TWEEN.Tween = function (object, group) {
 	this._onStopCallback = null;
 	this._group = group || TWEEN;
 	this._id = TWEEN.nextId();
+	this._isChainStopped = false;
 
 };
 
@@ -189,6 +190,8 @@ TWEEN.Tween.prototype = {
 
 		this._onStartCallbackFired = false;
 
+		this._isChainStopped = false;
+
 		this._startTime = time !== undefined ? typeof time === 'string' ? TWEEN.now() + parseFloat(time) : time : TWEEN.now();
 		this._startTime += this._delayTime;
 
@@ -231,6 +234,11 @@ TWEEN.Tween.prototype = {
 
 	stop: function () {
 
+		if (!this._isChainStopped) {
+			this._isChainStopped = true;
+			this.stopChainedTweens();
+		}
+
 		if (!this._isPlaying) {
 			return this;
 		}
@@ -245,7 +253,6 @@ TWEEN.Tween.prototype = {
 			this._onStopCallback(this._object);
 		}
 
-		this.stopChainedTweens();
 		return this;
 
 	},

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -942,6 +942,51 @@
 				test.done();
 			},
 
+
+			'Test TWEEN.Tween.stopChainedTweens()': function(test) {
+				var t = new TWEEN.Tween( {} ),
+					tStarted = false,
+					tCompleted = false,
+					t2 = new TWEEN.Tween( {} ),
+					t2Started = false;
+
+				TWEEN.removeAll();
+
+				t.to( {}, 1000 );
+				t2.delay(500).to( {}, 1000 );
+
+				t.chain( t2 );
+				t2.chain( t );
+
+				t.onStart(function() {
+					tStarted = true;
+				});
+
+				t.onComplete(function() {
+					tCompleted = true;
+				});
+
+				t2.onStart(function() {
+					test.equal( tStarted, true );
+					test.equal( tCompleted, true );
+					test.equal( t2Started, false );
+					t2Started = true;
+				});
+
+				test.equal( tStarted, false );
+				test.equal( t2Started, false );
+
+				t.start( 0 );
+				TWEEN.update( 1001 );
+				t.stop();
+
+				test.equal( tStarted, true );
+				test.equal( t2Started, false );
+				test.equal( TWEEN.getAll().length, 0 );
+				test.done();
+
+			},
+
 			'Test TWEEN.Tween.chain progressess into chained tweens': function(test) {
 
 				var obj = { t: 1000 };


### PR DESCRIPTION
The test was in fact indirectly testing the stopChainedTweens method. It is called inside the `stop` method.

This reverts commit 5647a709394db9e3f4fd265a495d475126d2ee78.

Fixes #406 