### PR TITLE
fix: yoyo should reset back to the beginning

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -128,6 +128,7 @@ define(function () { 'use strict';
 		this._valuesEnd = {};
 		this._valuesStartRepeat = {};
 		this._duration = 1000;
+		this._initialRepeat = 0;
 		this._repeat = 0;
 		this._repeatDelayTime = undefined;
 		this._yoyo = false;
@@ -165,7 +166,9 @@ define(function () { 'use strict';
 
 		to: function (properties, duration) {
 
-			this._valuesEnd = Object.create(properties);
+			for (var prop in properties) {
+				this._valuesEnd[prop] = properties[prop];
+			}
 
 			if (duration !== undefined) {
 				this._duration = duration;
@@ -187,6 +190,22 @@ define(function () { 'use strict';
 
 			this._group.add(this);
 
+			this._repeat = this._initialRepeat;
+
+			if (this._reversed) {
+				// If we were reversed (f.e. using the yoyo feature) then we need to
+				// flip the tween direction back to forward.
+
+				this._reversed = false;
+
+				var property;
+
+				for (property in this._valuesStartRepeat) {
+					this._swapEndStartRepeatValues(property);
+					this._valuesStart[property] = this._valuesStartRepeat[property];
+				}
+			}
+
 			this._isPlaying = true;
 
 			this._isPaused = false;
@@ -200,42 +219,37 @@ define(function () { 'use strict';
 
 			for (var property in this._valuesEnd) {
 
-				// Check if an Array was provided as property value
-				if (this._valuesEnd[property] instanceof Array) {
-
-					if (this._valuesEnd[property].length === 0) {
-						continue;
-					}
-
-					// handle relative values
-					this._valuesEnd[property] = this._valuesEnd[property].map(n => {
-						if (typeof n !== 'string') {
-							return n;
-						}
-
-						if (n.charAt(0) === '+' || n.charAt(0) === '-') {
-							return this._object[property] + parseFloat(n);
-						} else {
-							return parseFloat(n);
-						}
-					});
-
-					// Create a local copy of the Array with the start value at the front
-
-					this._valuesEnd[property] = [this._object[property]].concat(this._valuesEnd[property]);
-
-				}
-
 				// If `to()` specifies a property that doesn't exist in the source object,
 				// we should not set that property in the object
 				if (this._object[property] === undefined) {
 					continue;
 				}
 
-				// Save the starting value, but only once.
-				if (typeof(this._valuesStart[property]) === 'undefined') {
-					this._valuesStart[property] = this._object[property];
+				// Save the starting value only once.
+				if (typeof(this._valuesStart[property]) !== 'undefined') {
+					continue;
 				}
+
+				// Check if an Array was provided as property value
+				if (this._valuesEnd[property] instanceof Array) {
+
+					var endValues = this._valuesEnd[property];
+
+					if (endValues.length === 0) {
+						continue;
+					}
+
+					var startValue = this._object[property];
+
+					// handle an array of relative values
+					endValues = endValues.map(this._handleRelativeValue.bind(this, startValue));
+
+					// Create a local copy of the Array with the start value at the front
+					this._valuesEnd[property] = [startValue].concat(endValues);
+
+				}
+
+				this._valuesStart[property] = this._object[property];
 
 				if ((this._valuesStart[property] instanceof Array) === false) {
 					this._valuesStart[property] *= 1.0; // Ensures we're using numbers, not strings
@@ -342,6 +356,7 @@ define(function () { 'use strict';
 
 		repeat: function (times) {
 
+			this._initialRepeat = times;
 			this._repeat = times;
 			return this;
 
@@ -468,14 +483,7 @@ define(function () { 'use strict';
 				} else {
 
 					// Parses relative end values with start as base (e.g.: +10, -3)
-					if (typeof (end) === 'string') {
-
-						if (end.charAt(0) === '+' || end.charAt(0) === '-') {
-							end = start + parseFloat(end);
-						} else {
-							end = parseFloat(end);
-						}
-					}
+					end = this._handleRelativeValue(start, end);
 
 					// Protect against non numeric properties.
 					if (typeof (end) === 'number') {
@@ -506,15 +514,7 @@ define(function () { 'use strict';
 						}
 
 						if (this._yoyo) {
-							var tmp = this._valuesStartRepeat[property];
-
-							if (typeof(this._valuesEnd[property]) === 'string') {
-								this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property], 10);
-							} else {
-								this._valuesStartRepeat[property] = this._valuesEnd[property];
-							}
-
-							this._valuesEnd[property] = tmp;
+							this._swapEndStartRepeatValues(property);
 						}
 
 						this._valuesStart[property] = this._valuesStartRepeat[property];
@@ -559,6 +559,34 @@ define(function () { 'use strict';
 			}
 
 			return true;
+
+		},
+
+		_handleRelativeValue: function (start, end) {
+
+			if (typeof end !== 'string') {
+				return end;
+			}
+
+			if (end.charAt(0) === '+' || end.charAt(0) === '-') {
+				return start + parseFloat(end);
+			} else {
+				return parseFloat(end);
+			}
+
+		},
+
+		_swapEndStartRepeatValues: function (property) {
+
+			var tmp = this._valuesStartRepeat[property];
+
+			if (typeof(this._valuesEnd[property]) === 'string') {
+				this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property], 10);
+			} else {
+				this._valuesStartRepeat[property] = this._valuesEnd[property];
+			}
+
+			this._valuesEnd[property] = tmp;
 
 		}
 	};

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -126,6 +126,7 @@ TWEEN.Tween = function (object, group) {
 	this._valuesEnd = {};
 	this._valuesStartRepeat = {};
 	this._duration = 1000;
+	this._initialRepeat = 0;
 	this._repeat = 0;
 	this._repeatDelayTime = undefined;
 	this._yoyo = false;
@@ -163,7 +164,9 @@ TWEEN.Tween.prototype = {
 
 	to: function (properties, duration) {
 
-		this._valuesEnd = Object.create(properties);
+		for (var prop in properties) {
+			this._valuesEnd[prop] = properties[prop];
+		}
 
 		if (duration !== undefined) {
 			this._duration = duration;
@@ -185,6 +188,22 @@ TWEEN.Tween.prototype = {
 
 		this._group.add(this);
 
+		this._repeat = this._initialRepeat;
+
+		if (this._reversed) {
+			// If we were reversed (f.e. using the yoyo feature) then we need to
+			// flip the tween direction back to forward.
+
+			this._reversed = false;
+
+			var property;
+
+			for (property in this._valuesStartRepeat) {
+				this._swapEndStartRepeatValues(property);
+				this._valuesStart[property] = this._valuesStartRepeat[property];
+			}
+		}
+
 		this._isPlaying = true;
 
 		this._isPaused = false;
@@ -198,42 +217,37 @@ TWEEN.Tween.prototype = {
 
 		for (var property in this._valuesEnd) {
 
-			// Check if an Array was provided as property value
-			if (this._valuesEnd[property] instanceof Array) {
-
-				if (this._valuesEnd[property].length === 0) {
-					continue;
-				}
-
-				// handle relative values
-				this._valuesEnd[property] = this._valuesEnd[property].map(n => {
-					if (typeof n !== 'string') {
-						return n;
-					}
-
-					if (n.charAt(0) === '+' || n.charAt(0) === '-') {
-						return this._object[property] + parseFloat(n);
-					} else {
-						return parseFloat(n);
-					}
-				});
-
-				// Create a local copy of the Array with the start value at the front
-
-				this._valuesEnd[property] = [this._object[property]].concat(this._valuesEnd[property]);
-
-			}
-
 			// If `to()` specifies a property that doesn't exist in the source object,
 			// we should not set that property in the object
 			if (this._object[property] === undefined) {
 				continue;
 			}
 
-			// Save the starting value, but only once.
-			if (typeof(this._valuesStart[property]) === 'undefined') {
-				this._valuesStart[property] = this._object[property];
+			// Save the starting value only once.
+			if (typeof(this._valuesStart[property]) !== 'undefined') {
+				continue;
 			}
+
+			// Check if an Array was provided as property value
+			if (this._valuesEnd[property] instanceof Array) {
+
+				var endValues = this._valuesEnd[property];
+
+				if (endValues.length === 0) {
+					continue;
+				}
+
+				var startValue = this._object[property];
+
+				// handle an array of relative values
+				endValues = endValues.map(this._handleRelativeValue.bind(this, startValue));
+
+				// Create a local copy of the Array with the start value at the front
+				this._valuesEnd[property] = [startValue].concat(endValues);
+
+			}
+
+			this._valuesStart[property] = this._object[property];
 
 			if ((this._valuesStart[property] instanceof Array) === false) {
 				this._valuesStart[property] *= 1.0; // Ensures we're using numbers, not strings
@@ -340,6 +354,7 @@ TWEEN.Tween.prototype = {
 
 	repeat: function (times) {
 
+		this._initialRepeat = times;
 		this._repeat = times;
 		return this;
 
@@ -466,14 +481,7 @@ TWEEN.Tween.prototype = {
 			} else {
 
 				// Parses relative end values with start as base (e.g.: +10, -3)
-				if (typeof (end) === 'string') {
-
-					if (end.charAt(0) === '+' || end.charAt(0) === '-') {
-						end = start + parseFloat(end);
-					} else {
-						end = parseFloat(end);
-					}
-				}
+				end = this._handleRelativeValue(start, end);
 
 				// Protect against non numeric properties.
 				if (typeof (end) === 'number') {
@@ -504,15 +512,7 @@ TWEEN.Tween.prototype = {
 					}
 
 					if (this._yoyo) {
-						var tmp = this._valuesStartRepeat[property];
-
-						if (typeof(this._valuesEnd[property]) === 'string') {
-							this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property], 10);
-						} else {
-							this._valuesStartRepeat[property] = this._valuesEnd[property];
-						}
-
-						this._valuesEnd[property] = tmp;
+						this._swapEndStartRepeatValues(property);
 					}
 
 					this._valuesStart[property] = this._valuesStartRepeat[property];
@@ -557,6 +557,34 @@ TWEEN.Tween.prototype = {
 		}
 
 		return true;
+
+	},
+
+	_handleRelativeValue: function (start, end) {
+
+		if (typeof end !== 'string') {
+			return end;
+		}
+
+		if (end.charAt(0) === '+' || end.charAt(0) === '-') {
+			return start + parseFloat(end);
+		} else {
+			return parseFloat(end);
+		}
+
+	},
+
+	_swapEndStartRepeatValues: function (property) {
+
+		var tmp = this._valuesStartRepeat[property];
+
+		if (typeof(this._valuesEnd[property]) === 'string') {
+			this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property], 10);
+		} else {
+			this._valuesStartRepeat[property] = this._valuesEnd[property];
+		}
+
+		this._valuesEnd[property] = tmp;
 
 	}
 };

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -132,6 +132,7 @@
 		this._valuesEnd = {};
 		this._valuesStartRepeat = {};
 		this._duration = 1000;
+		this._initialRepeat = 0;
 		this._repeat = 0;
 		this._repeatDelayTime = undefined;
 		this._yoyo = false;
@@ -169,7 +170,9 @@
 
 		to: function (properties, duration) {
 
-			this._valuesEnd = Object.create(properties);
+			for (var prop in properties) {
+				this._valuesEnd[prop] = properties[prop];
+			}
 
 			if (duration !== undefined) {
 				this._duration = duration;
@@ -191,6 +194,22 @@
 
 			this._group.add(this);
 
+			this._repeat = this._initialRepeat;
+
+			if (this._reversed) {
+				// If we were reversed (f.e. using the yoyo feature) then we need to
+				// flip the tween direction back to forward.
+
+				this._reversed = false;
+
+				var property;
+
+				for (property in this._valuesStartRepeat) {
+					this._swapEndStartRepeatValues(property);
+					this._valuesStart[property] = this._valuesStartRepeat[property];
+				}
+			}
+
 			this._isPlaying = true;
 
 			this._isPaused = false;
@@ -204,42 +223,37 @@
 
 			for (var property in this._valuesEnd) {
 
-				// Check if an Array was provided as property value
-				if (this._valuesEnd[property] instanceof Array) {
-
-					if (this._valuesEnd[property].length === 0) {
-						continue;
-					}
-
-					// handle relative values
-					this._valuesEnd[property] = this._valuesEnd[property].map(n => {
-						if (typeof n !== 'string') {
-							return n;
-						}
-
-						if (n.charAt(0) === '+' || n.charAt(0) === '-') {
-							return this._object[property] + parseFloat(n);
-						} else {
-							return parseFloat(n);
-						}
-					});
-
-					// Create a local copy of the Array with the start value at the front
-
-					this._valuesEnd[property] = [this._object[property]].concat(this._valuesEnd[property]);
-
-				}
-
 				// If `to()` specifies a property that doesn't exist in the source object,
 				// we should not set that property in the object
 				if (this._object[property] === undefined) {
 					continue;
 				}
 
-				// Save the starting value, but only once.
-				if (typeof(this._valuesStart[property]) === 'undefined') {
-					this._valuesStart[property] = this._object[property];
+				// Save the starting value only once.
+				if (typeof(this._valuesStart[property]) !== 'undefined') {
+					continue;
 				}
+
+				// Check if an Array was provided as property value
+				if (this._valuesEnd[property] instanceof Array) {
+
+					var endValues = this._valuesEnd[property];
+
+					if (endValues.length === 0) {
+						continue;
+					}
+
+					var startValue = this._object[property];
+
+					// handle an array of relative values
+					endValues = endValues.map(this._handleRelativeValue.bind(this, startValue));
+
+					// Create a local copy of the Array with the start value at the front
+					this._valuesEnd[property] = [startValue].concat(endValues);
+
+				}
+
+				this._valuesStart[property] = this._object[property];
 
 				if ((this._valuesStart[property] instanceof Array) === false) {
 					this._valuesStart[property] *= 1.0; // Ensures we're using numbers, not strings
@@ -346,6 +360,7 @@
 
 		repeat: function (times) {
 
+			this._initialRepeat = times;
 			this._repeat = times;
 			return this;
 
@@ -472,14 +487,7 @@
 				} else {
 
 					// Parses relative end values with start as base (e.g.: +10, -3)
-					if (typeof (end) === 'string') {
-
-						if (end.charAt(0) === '+' || end.charAt(0) === '-') {
-							end = start + parseFloat(end);
-						} else {
-							end = parseFloat(end);
-						}
-					}
+					end = this._handleRelativeValue(start, end);
 
 					// Protect against non numeric properties.
 					if (typeof (end) === 'number') {
@@ -510,15 +518,7 @@
 						}
 
 						if (this._yoyo) {
-							var tmp = this._valuesStartRepeat[property];
-
-							if (typeof(this._valuesEnd[property]) === 'string') {
-								this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property], 10);
-							} else {
-								this._valuesStartRepeat[property] = this._valuesEnd[property];
-							}
-
-							this._valuesEnd[property] = tmp;
+							this._swapEndStartRepeatValues(property);
 						}
 
 						this._valuesStart[property] = this._valuesStartRepeat[property];
@@ -563,6 +563,34 @@
 			}
 
 			return true;
+
+		},
+
+		_handleRelativeValue: function (start, end) {
+
+			if (typeof end !== 'string') {
+				return end;
+			}
+
+			if (end.charAt(0) === '+' || end.charAt(0) === '-') {
+				return start + parseFloat(end);
+			} else {
+				return parseFloat(end);
+			}
+
+		},
+
+		_swapEndStartRepeatValues: function (property) {
+
+			var tmp = this._valuesStartRepeat[property];
+
+			if (typeof(this._valuesEnd[property]) === 'string') {
+				this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property], 10);
+			} else {
+				this._valuesStartRepeat[property] = this._valuesEnd[property];
+			}
+
+			this._valuesEnd[property] = tmp;
 
 		}
 	};

--- a/examples/10_yoyo.html
+++ b/examples/10_yoyo.html
@@ -10,6 +10,11 @@
 			<h1><a href="http://github.com/tweenjs/tween.js">tween.js</a></h1>
 			<h2>10 _ yoyo</h2>
 			<p>Demonstrating the yoyo() feature.</p>
+			<button onclick="restart()">restart</button>
+			<button onclick="stop()">stop</button>
+			<button onclick="start()">start</button>
+			<button onclick="pause()">pause</button>
+			<button onclick="resume()">resume</button>
 		</div>
 		<div style="position: absolute; top: 100px; left: 400px; ">
 			<div id="target1" data-rotation="0" data-y="0" class="box" style="left: 0px; top: 0px">
@@ -32,6 +37,8 @@
 
 			init();
 			animate();
+
+			var restart, stop, start, pause, resume
 
 			function init() {
 				var target1 = document.getElementById( 'target1' ),
@@ -78,6 +85,41 @@
 							updateBox( target4, object );
 						})
 						.start();
+
+				restart = function() {
+					tween1.stop().start()
+					tween2.stop().start()
+					tween3.stop().start()
+					tween4.stop().start()
+				}
+
+				stop = function() {
+					tween1.stop()
+					tween2.stop()
+					tween3.stop()
+					tween4.stop()
+				}
+
+				start = function() {
+					tween1.start()
+					tween2.start()
+					tween3.start()
+					tween4.start()
+				}
+
+				pause = function() {
+					tween1.pause()
+					tween2.pause()
+					tween3.pause()
+					tween4.pause()
+				}
+
+				resume = function() {
+					tween1.resume()
+					tween2.resume()
+					tween3.resume()
+					tween4.resume()
+				}
 			}
 
 			function animate( time ) {
@@ -123,10 +165,10 @@
 				background: #cfc;
 			}
 			#target3 {
-				background: deeppink;
+				background: orange;
 			}
 			#target4 {
-				background: cyan;
+				background: skyblue;
 			}
 		</style>
 	</body>

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1069,6 +1069,51 @@
 
 			},
 
+			'Test yoyo can be stopped and restarted properly': function(test) {
+
+				TWEEN.removeAll();
+
+				var obj = { x: 0 },
+					t = new TWEEN.Tween( obj ).to( { x: 100 }, 100 ).repeat( 1 ).yoyo(true);
+
+				t.start( 0 );
+
+				TWEEN.update( 0 );
+				test.equal( obj.x, 0 );
+
+				TWEEN.update( 25 );
+				test.equal( obj.x, 25 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.x, 100 );
+
+				TWEEN.update( 125 );
+				test.equal( obj.x, 75 );
+
+				t.stop();
+				t.start( 0 );
+
+				TWEEN.update( 0 );
+				test.equal( obj.x, 0 );
+
+				TWEEN.update( 25 );
+				test.equal( obj.x, 25 );
+
+				TWEEN.update( 100 );
+				test.equal( obj.x, 100 );
+
+				TWEEN.update( 125 );
+				test.equal( obj.x, 75 );
+
+				TWEEN.update( 200 );
+				test.equal( obj.x, 0 );
+
+				TWEEN.update( 225 );
+				test.equal( obj.x, 0 );
+
+				test.done();
+			},
+
 			'Test TWEEN.Tween.stopChainedTweens()': function(test) {
 				var t = new TWEEN.Tween( {} ),
 					tStarted = false,


### PR DESCRIPTION
This is working towards resetting state properly after having stopped a tween. All tests currently pass, but the update yoyo example's `restart` button doesn't work as one would expect. Once we clean up state reset and fix the yoyo's ability to restart, then we should add some tests for it.

Fixes https://github.com/tweenjs/tween.js/issues/512