### PR TITLE
Typing: time parameter in update() and start() is now optional

### DIFF
--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -70,7 +70,7 @@ export class Tween<T extends UnknownProps> {
 		return this
 	}
 
-	start(time: number): this {
+	start(time?: number): this {
 		if (this._isPlaying) {
 			return this
 		}
@@ -319,9 +319,12 @@ export class Tween<T extends UnknownProps> {
 		return this
 	}
 
-	update(time: number): boolean {
+	update(time?: number): boolean {
 		let property
 		let elapsed
+
+		time = time !== undefined ? time : TWEEN.now()
+
 		const endTime = this._startTime + this._duration
 
 		if (time > endTime && !this._isPlaying) {


### PR DESCRIPTION
Hi, 

I made the `time` parameter optional, to reflect the examples and documentation. For `update()`, the TS compiler warned me of a possibly undefined value, so I added a line of code to make sure the current time is used if none is provided. This is consistent to what I read in the documentation and the tests all pass, but please review this change critically since actually don't know much about Tween.js.

