### PR TITLE
Update yoyo function in user guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -176,7 +176,12 @@ Check the [Repeat](../examples/08_repeat.html) example.
 
 ### `yoyo`
 
-This function only has effect if used along with `repeat`. When active, the behaviour of the tween will be _like a yoyo_, i.e. it will bounce to and from the start and end values, instead of just repeating the same sequence from the beginning.
+This function only has effect if used along with `repeat`. When active, the behaviour of the tween will be _like a yoyo_, i.e. it will bounce to and from the start and end values, instead of just repeating the same sequence from the beginning:
+
+```
+tween.yoyo(false) // default value, animation will only go from start to end value
+tween.yoyo(true) // tween will 'yoyo' between start and end values
+```
 
 ### `delay`
 


### PR DESCRIPTION
The yoyo function currently has no code block example. This leaves it up to the user to guess whether calling the function sets yoyo to true or if a value needs to be passed in without referring to the code. Added lines to show that boolean values should be passed in to the function.