### PR TITLE
expose duration with getDuration method

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -91,7 +91,7 @@ declare module "TWEEN" {
         static nextId(): number;
     }
 
-    const VERSION = "18.5.0";
+    const VERSION = "18.6.0";
 
     /**
      * Controlling groups of tweens
@@ -216,6 +216,7 @@ declare module "TWEEN" {
         private _isChainStopped;
         constructor(_object: T, _group?: Group);
         getId(): number;
+        getDuration(): number;
         isPlaying(): boolean;
         isPaused(): boolean;
         to(properties: UnknownProps, duration?: number): this;

--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -402,6 +402,9 @@ define(function () { 'use strict';
         Tween.prototype.getId = function () {
             return this._id;
         };
+        Tween.prototype.getDuration = function () {
+            return this._duration;
+        };
         Tween.prototype.isPlaying = function () {
             return this._isPlaying;
         };
@@ -409,7 +412,6 @@ define(function () { 'use strict';
             return this._isPaused;
         };
         Tween.prototype.to = function (properties, duration) {
-            // to (properties, duration) {
             for (var prop in properties) {
                 this._valuesEnd[prop] = properties[prop];
             }
@@ -746,7 +748,7 @@ define(function () { 'use strict';
         return Tween;
     }());
 
-    var VERSION = '18.5.0';
+    var VERSION = '18.6.0';
 
     /**
      * Tween.js - Licensed under the MIT license

--- a/dist/tween.cjs.js
+++ b/dist/tween.cjs.js
@@ -402,6 +402,9 @@ var Tween = /** @class */ (function () {
     Tween.prototype.getId = function () {
         return this._id;
     };
+    Tween.prototype.getDuration = function () {
+        return this._duration;
+    };
     Tween.prototype.isPlaying = function () {
         return this._isPlaying;
     };
@@ -409,7 +412,6 @@ var Tween = /** @class */ (function () {
         return this._isPaused;
     };
     Tween.prototype.to = function (properties, duration) {
-        // to (properties, duration) {
         for (var prop in properties) {
             this._valuesEnd[prop] = properties[prop];
         }
@@ -746,7 +748,7 @@ var Tween = /** @class */ (function () {
     return Tween;
 }());
 
-var VERSION = '18.5.0';
+var VERSION = '18.6.0';
 
 /**
  * Tween.js - Licensed under the MIT license

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -400,6 +400,9 @@ var Tween = /** @class */ (function () {
     Tween.prototype.getId = function () {
         return this._id;
     };
+    Tween.prototype.getDuration = function () {
+        return this._duration;
+    };
     Tween.prototype.isPlaying = function () {
         return this._isPlaying;
     };
@@ -407,7 +410,6 @@ var Tween = /** @class */ (function () {
         return this._isPaused;
     };
     Tween.prototype.to = function (properties, duration) {
-        // to (properties, duration) {
         for (var prop in properties) {
             this._valuesEnd[prop] = properties[prop];
         }
@@ -744,7 +746,7 @@ var Tween = /** @class */ (function () {
     return Tween;
 }());
 
-var VERSION = '18.5.0';
+var VERSION = '18.6.0';
 
 /**
  * Tween.js - Licensed under the MIT license

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -406,6 +406,9 @@
         Tween.prototype.getId = function () {
             return this._id;
         };
+        Tween.prototype.getDuration = function () {
+            return this._duration;
+        };
         Tween.prototype.isPlaying = function () {
             return this._isPlaying;
         };
@@ -413,7 +416,6 @@
             return this._isPaused;
         };
         Tween.prototype.to = function (properties, duration) {
-            // to (properties, duration) {
             for (var prop in properties) {
                 this._valuesEnd[prop] = properties[prop];
             }
@@ -750,7 +752,7 @@
         return Tween;
     }());
 
-    var VERSION = '18.5.0';
+    var VERSION = '18.6.0';
 
     /**
      * Tween.js - Licensed under the MIT license

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -45,6 +45,10 @@ export class Tween<T extends UnknownProps> {
 		return this._id
 	}
 
+	getDuration(): number {
+		return this._duration;
+	}
+
 	isPlaying(): boolean {
 		return this._isPlaying
 	}

--- a/src/Version.ts
+++ b/src/Version.ts
@@ -1,2 +1,2 @@
-const VERSION = '18.5.0'
+const VERSION = '18.6.0'
 export default VERSION

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1562,6 +1562,12 @@
 				test.done()
 			},
 
+			'Get the duration with .getDuration': function (test) {
+				var t = new TWEEN.Tween({}).to({}).duration(500).start();
+				test.equal(t.getDuration(), 500);
+				test.done();
+			},
+
 			"Tween.group sets the tween's group.": function (test) {
 				var group = new TWEEN.Group()
 


### PR DESCRIPTION
Since the `chain` method doesn't create a new animation object (it just starts the given tween whenever the current one finishes), I wanted to create my own mechanism to manage a sequence of tweens. However, there is no way to know a duration of a Tween after it is created, which is information I need to manage a sequence properly.

This PR adds a `getDuration()` method to `Tween` that gets the duration. It is analogous to the `getId` method.