### PR TITLE
Add new method Tween.startFromCurrentValues

### DIFF
--- a/examples/18_start_from_current_values.html
+++ b/examples/18_start_from_current_values.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Tween.js / hello world!</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<link href="css/style.css" media="screen" rel="stylesheet" type="text/css" />
+	</head>
+	<body>
+		<div id="info">
+			<h1><a href="http://github.com/tweenjs/tween.js">tween.js</a></h1>
+			<h2>18 _ start from current values</h2>
+			<p>Example for illustrating the startFromCurrentValues() functionality.</p>
+			<button id="start-tween">
+				Start tween
+			</button>
+			<button id="up">
+				↑
+			</button>
+			<button id="down">
+				↓
+			</button>
+			<button id="left">
+				←
+			</button>
+			<button id="right">
+				→
+			</button>
+		</div>
+		<div
+			id="target"
+			style="
+				position: absolute;
+				top: 200px;
+				left: 400px;
+				width: 100px;
+				height: 100px;
+				background: #a0dde9;
+				padding: 1em;
+			"
+		></div>
+
+		<script src="../dist/tween.umd.js"></script>
+		<script src="js/RequestAnimationFrame.js"></script>
+		<script>
+			var position
+			var target
+			var tween, tweenBack
+
+			init()
+			animate()
+
+			function init() {
+				position = {x: 400, y: 200}
+				target = document.getElementById('target')
+				tween = new TWEEN.Tween(position).to({x: 700, y: 200}, 2000).easing(TWEEN.Easing.Elastic.InOut).onUpdate(update)
+
+				document.getElementById('start-tween').addEventListener('click', () => {
+					tween.startFromCurrentValues() // start the tween from its current position
+					animate() // call animate as we unregister the handler if TWEEN.update(time) returns false
+				})
+
+				registerArrowButtonEventListeners()
+			}
+
+			//If we register the callback animate, but the TWEEN.update(time) returns false,
+			//cancel/unregister the handler
+			function animate(time) {
+				var id = requestAnimationFrame(animate)
+
+				var result = TWEEN.update(time)
+
+				if (!result) cancelAnimationFrame(id)
+			}
+
+			function update() {
+				target.style.left = position.x + 'px'
+				target.style.top = position.y + 'px'
+			}
+
+			//Add event listeners to each of the arrow buttons
+			function registerArrowButtonEventListeners() {
+				document.getElementById('up').addEventListener('click', moveUp)
+				document.getElementById('down').addEventListener('click', moveDown)
+				document.getElementById('left').addEventListener('click', moveLeft)
+				document.getElementById('right').addEventListener('click', moveRight)
+			}
+
+			// Arrow button callbacks
+			function moveLeft() {
+				position.x -= 20
+				update()
+			}
+
+			function moveRight() {
+				position.x += 20
+				update()
+			}
+
+			function moveUp() {
+				position.y -= 20
+				update()
+			}
+
+			function moveDown() {
+				position.y += 20
+				update()
+			}
+		</script>
+	</body>
+</html>

--- a/examples/css/style.css
+++ b/examples/css/style.css
@@ -11,6 +11,23 @@ h2 {
 	font-weight: normal;
 }
 
+button {
+	cursor: pointer;
+	color: #333;
+	background: #fff;
+	border: 2px solid #333;
+	padding: 10px;
+	border-radius: 10px;
+	font-weight: bold;
+	font-size: 20px;
+	transition: all 150ms ease-out;
+}
+
+button:hover {
+	background: #333;
+	color: #fff;
+}
+
 #info {
 	position: absolute;
 	top: 0;

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -130,7 +130,7 @@ export class Tween<T extends UnknownProps> {
 		_valuesStart: UnknownProps,
 		_valuesEnd: UnknownProps,
 		_valuesStartRepeat: UnknownProps,
-		_overrideStartingValues: boolean,
+		overrideStartingValues: boolean,
 	): void {
 		for (const property in _valuesEnd) {
 			const startValue = _object[property]
@@ -179,11 +179,11 @@ export class Tween<T extends UnknownProps> {
 					_valuesStart[property],
 					_valuesEnd[property],
 					_valuesStartRepeat[property],
-					_overrideStartingValues,
+					overrideStartingValues,
 				)
 			} else {
 				// Save the starting value, but only once unless override is requested.
-				if (typeof _valuesStart[property] === 'undefined' || _overrideStartingValues) {
+				if (typeof _valuesStart[property] === 'undefined' || overrideStartingValues) {
 					_valuesStart[property] = startValue
 				}
 

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -78,7 +78,7 @@ export class Tween<T extends UnknownProps> {
 		return this
 	}
 
-	start(time?: number): this {
+	start(time?: number, overrideStartingValues?: boolean): this {
 		if (this._isPlaying) {
 			return this
 		}
@@ -111,9 +111,18 @@ export class Tween<T extends UnknownProps> {
 		this._startTime = time !== undefined ? (typeof time === 'string' ? now() + parseFloat(time) : time) : now()
 		this._startTime += this._delayTime
 
-		this._setupProperties(this._object, this._valuesStart, this._valuesEnd, this._valuesStartRepeat)
-
+		this._setupProperties(
+			this._object,
+			this._valuesStart,
+			this._valuesEnd,
+			this._valuesStartRepeat,
+			overrideStartingValues === true,
+		)
 		return this
+	}
+
+	startFromCurrentValues(time?: number): this {
+		return this.start(time, true)
 	}
 
 	private _setupProperties(
@@ -121,6 +130,7 @@ export class Tween<T extends UnknownProps> {
 		_valuesStart: UnknownProps,
 		_valuesEnd: UnknownProps,
 		_valuesStartRepeat: UnknownProps,
+		_overrideStartingValues: boolean,
 	): void {
 		for (const property in _valuesEnd) {
 			const startValue = _object[property]
@@ -164,10 +174,16 @@ export class Tween<T extends UnknownProps> {
 
 				// eslint-disable-next-line
 				// @ts-ignore FIXME?
-				this._setupProperties(startValue, _valuesStart[property], _valuesEnd[property], _valuesStartRepeat[property])
+				this._setupProperties(
+					startValue,
+					_valuesStart[property],
+					_valuesEnd[property],
+					_valuesStartRepeat[property],
+					_overrideStartingValues,
+				)
 			} else {
-				// Save the starting value, but only once.
-				if (typeof _valuesStart[property] === 'undefined') {
+				// Save the starting value, but only once unless override is requested.
+				if (typeof _valuesStart[property] === 'undefined' || _overrideStartingValues) {
 					_valuesStart[property] = startValue
 				}
 
@@ -341,7 +357,7 @@ export class Tween<T extends UnknownProps> {
 
 		if (!this._goToEnd && !this._isPlaying) {
 			if (time > endTime) return false
-			if (autoStart) this.start(time)
+			if (autoStart) this.start(time, true)
 		}
 
 		this._goToEnd = false
@@ -415,7 +431,7 @@ export class Tween<T extends UnknownProps> {
 				for (let i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
 					// Make the chained tweens start exactly at the time they should,
 					// even if the `update()` method was called way past the duration of the tween
-					this._chainedTweens[i].start(this._startTime + this._duration)
+					this._chainedTweens[i].start(this._startTime + this._duration, false)
 				}
 
 				this._isPlaying = false

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -78,7 +78,7 @@ export class Tween<T extends UnknownProps> {
 		return this
 	}
 
-	start(time: number = now(), overrideStartingValues: boolean = false): this {
+	start(time: number = now(), overrideStartingValues = false): this {
 		if (this._isPlaying) {
 			return this
 		}

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -801,6 +801,39 @@ export const tests = {
 		test.done()
 	},
 
+	'Test TWEEN.Tween.startFromCurrentValues'(test: Test): void {
+		const obj = {x: 0},
+			t = new TWEEN.Tween(obj).to({x: 100})
+
+		TWEEN.removeAll()
+
+		test.equal(obj.x, 0)
+
+		// x == 0
+		t.start(0)
+		TWEEN.update(0)
+
+		test.equal(obj.x, 0)
+
+		TWEEN.update(1500)
+		test.equal(obj.x, 100)
+
+		obj.x = 200
+
+		t.startFromCurrentValues(0)
+
+		TWEEN.update(0)
+		test.equal(obj.x, 200)
+
+		TWEEN.update(500)
+		test.equal(obj.x, 150)
+
+		TWEEN.update(1000)
+		test.equal(obj.x, 100)
+
+		test.done()
+	},
+
 	'Test TWEEN.Tween.onStart'(test: Test): void {
 		const obj = {},
 			t = new TWEEN.Tween(obj)


### PR DESCRIPTION
WIP as I havent added an example yet, I will if you are happy with the addition to the API.

## What? 
New method: `Tween.startFromCurrentValues(time?: number)`
* Starts the tween but using the current values of the tweened properties, rather than the values the first time start was called
* This calls start but passes `true` to an added second param: `overrideStartingValues` which is passed through to `_setupProperties`

## Why?
We are using `tween.js` in a game engine where expected behaviour of animations is for them to start from the values held by the sprites when the animation starts. Animations can be run multiple times, and triggered by vast number of events. The animated sprites could have completely different values on subsequent starts than they did the first time start was called.
I believe this was formerly the behaviour of start?