### PR TITLE
fix: end()ed tweens would leak and remain as zombies (unkillable with stop()), and would rise again from the dead if before the delayTime

### DIFF
--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -418,6 +418,9 @@ export class Tween<T extends UnknownProps> {
 					this._chainedTweens[i].start(this._startTime + this._duration)
 				}
 
+				// eslint-disable-next-line
+				this._group && this._group.remove(this as any)
+
 				this._isPlaying = false
 
 				return false


### PR DESCRIPTION
Tweens that reach their end or have `end()` called on them are not removed from their group, but do have their `_isPlaying` set to false, meaning they cannot then be removed with `stop()`, forever stuck between life and death with their `update()` still always called.

This means that trying to jump a tween to the end early and then stop it (`tween.end().stop()`) would instead leave it as a zombied instance.

As a bonus effect, calling `tween.end().stop()` on a tween with a `delay()`, which has not yet passed would result in the tween autostarting later on and raising from the dead.