### PR TITLE
Multiple `.start()` and `.to(prop:[])`

### DIFF
--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -44,6 +44,7 @@ export class Tween<T extends UnknownProps> {
 	private _onStopCallback?: (object: T) => void
 	private _id = Sequence.nextId()
 	private _isChainStopped = false
+	private _hasSetupProperty = false
 
 	constructor(private _object: T, private _group: Group | false = mainGroup) {}
 
@@ -65,6 +66,7 @@ export class Tween<T extends UnknownProps> {
 		// currently no opt-out).
 		// for (const prop in properties) this._valuesEnd[prop] = properties[prop]
 		this._valuesEnd = Object.create(properties)
+		this._hasSetupProperty = false
 
 		if (duration !== undefined) {
 			this._duration = duration
@@ -146,7 +148,9 @@ export class Tween<T extends UnknownProps> {
 				endValues = endValues.map(this._handleRelativeValue.bind(this, startValue as number))
 
 				// Create a local copy of the Array with the start value at the front
-				_valuesEnd[property] = [startValue].concat(endValues)
+				if (!this._hasSetupProperty) {
+					_valuesEnd[property] = [_valuesStart[property] ?? startValue].concat(endValues)
+				}
 			}
 
 			// handle the deepness of the values
@@ -186,6 +190,7 @@ export class Tween<T extends UnknownProps> {
 				}
 			}
 		}
+		this._hasSetupProperty = true
 	}
 
 	stop(): this {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1917,6 +1917,52 @@ export const tests = {
 
 		test.done()
 	},
+
+	'Tween.to(value:[number]) and Tween.to(value:number) return the same result after multiple .start()'(
+		test: Test,
+	): void {
+		const toNumber = {x: 1.0}
+		const toArray = {x: [1.0]}
+		const targetNumber = {x: 0.0}
+		const targetArray = {x: 0.0}
+		const tweenNumber = new TWEEN.Tween(targetNumber).to(toNumber, 100)
+		const tweenArray = new TWEEN.Tween(targetArray).to(toArray, 100)
+
+		tweenNumber.start(0)
+		tweenArray.start(0)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(37)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(50)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(100)
+		test.equal(targetNumber.x, targetArray.x)
+
+		tweenNumber.start(100)
+		tweenArray.start(100)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(137)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(150)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(200)
+		test.equal(targetNumber.x, targetArray.x)
+
+		//should keep _valuesStart after .to() function
+		tweenNumber.to({x: 2.0})
+		tweenArray.to({x: [2.0]})
+		tweenNumber.start(200)
+		tweenArray.start(200)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(237)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(250)
+		test.equal(targetNumber.x, targetArray.x)
+		TWEEN.update(300)
+		test.equal(targetNumber.x, targetArray.x)
+
+		test.done()
+	},
 }
 
 type Test = {


### PR DESCRIPTION
## Related Issues

- Animation on repeat speeds up over time. #378

## Purpose of this Pull Request

This PR fixes the Issue of tween acceleration on multiple .start().

If an object with an array is passed to `.to()`, `_valuesEnd` will be irreversibly changed when `.start()` is executed multiple times.
As a result, each time you run `.start()`, animation will be faster.

## Details of the changes

1. Added test cases.
1. Added `_hasSetupProperty` flag to check if `_setupProperties()` has been executed.
1. If you reconfigure `.to()`, startValue will be changed to the current value of the tween target object. Check `_valuesStart` and keep it if it is already initialized.

https://github.com/tweenjs/tween.js/blob/ae24c58c8b57b2079151ae2c3c63f2bb501c8b2b/src/Tween.ts#L169-L172

I used this code as a reference for change point 3.

## Related pull requests

- Fix dynamic to with array values #585

I think it might be difficult to merge this PR as-is, because of conflicts with features such as `dynamic to` and `_propertiesAreSetUp`. In that case, I hope the added test cases will contribute to everyone.