### PR TITLE
Add pow easing function

### DIFF
--- a/examples/17_generate_pow.html
+++ b/examples/17_generate_pow.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Tween.js / easing with a power of number</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<style>
+			body {
+				margin: 0px;
+			}
+
+			#target {
+				font-size: 13px;
+				padding: 0px 32px;
+			}
+		</style>
+		<link href="css/style.css" media="screen" rel="stylesheet" type="text/css" />
+	</head>
+	<body>
+		<div id="info" style="position: relative;">
+			<h1><a href="http://github.com/tweenjs/tween.js">tween.js</a></h1>
+			<h2>17 _ Easing with Pow</h2>
+			<p>TWEEN.Easing.generatePow() provides easing with a power of number.</p>
+		</div>
+
+		<div id="target"></div>
+
+		<script src="../dist/tween.umd.js"></script>
+		<script src="js/RequestAnimationFrame.js"></script>
+		<script src="js/createGraph.js"></script>
+		<script>
+			window.addEventListener('load', function () {
+				init()
+				animate()
+			})
+
+			function init() {
+				var target = document.getElementById('target')
+
+				const addGraph = pow => {
+					target.appendChild(createGraph(`Power"${pow}".In`, TWEEN.Easing.generatePow(pow).In))
+					target.appendChild(createGraph(`Power"${pow}".Out`, TWEEN.Easing.generatePow(pow).Out))
+					target.appendChild(createGraph(`Power"${pow}".InOut`, TWEEN.Easing.generatePow(pow).InOut))
+				}
+				target.appendChild(createGraph('Power1', TWEEN.Easing.generatePow(1).In))
+
+				target.appendChild(document.createElement('br'))
+
+				addGraph(2)
+				addGraph(3)
+
+				target.appendChild(document.createElement('br'))
+
+				addGraph(4)
+				addGraph(5)
+
+				target.appendChild(document.createElement('br'))
+
+				addGraph(5.8)
+				target.appendChild(createGraph(`Exponential.In`, TWEEN.Easing.Exponential.In))
+				target.appendChild(createGraph(`Exponential.Out`, TWEEN.Easing.Exponential.Out))
+				target.appendChild(createGraph(`Exponential.InOut`, TWEEN.Easing.Exponential.InOut))
+			}
+
+			function animate(time) {
+				requestAnimationFrame(animate)
+
+				TWEEN.update(time)
+			}
+		</script>
+	</body>
+</html>

--- a/src/Easing.ts
+++ b/src/Easing.ts
@@ -195,6 +195,30 @@ const Easing = {
 			return Easing.Bounce.Out(amount * 2 - 1) * 0.5 + 0.5
 		},
 	},
+	generatePow: function (
+		power = 4,
+	): {
+		In(amount: number): number
+		Out(amount: number): number
+		InOut(amount: number): number
+	} {
+		power = power < 1.0 ? 1.0 : power
+		power = power > 10000 ? 10000 : power
+		return {
+			In: function (amount: number): number {
+				return amount ** power
+			},
+			Out: function (amount: number): number {
+				return 1 - (1 - amount) ** power
+			},
+			InOut: function (amount: number): number {
+				if (amount < 0.5) {
+					return (amount * 2) ** power / 2
+				}
+				return (1 - (2 - amount * 2) ** power) / 2 + 0.5
+			},
+		}
+	},
 }
 
 export default Easing

--- a/src/Easing.ts
+++ b/src/Easing.ts
@@ -202,7 +202,7 @@ const Easing = {
 		Out(amount: number): number
 		InOut(amount: number): number
 	} {
-		power = power < 1.0 ? 1.0 : power
+		power = power < Number.EPSILON ? Number.EPSILON : power
 		power = power > 10000 ? 10000 : power
 		return {
 			In: function (amount: number): number {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -2021,7 +2021,6 @@ export const tests = {
 
 	'Test TWEEN.Easing.generatePow(1) equals Linear'(test: Test): void {
 		const ease1 = TWEEN.Easing.generatePow(1)
-		const easeMinus = TWEEN.Easing.generatePow(-1)
 
 		const compareWithLinear = (ease: EasingFunctionGroup, amount: number) => {
 			const linearResult = TWEEN.Easing.Linear.None(amount)
@@ -2030,20 +2029,12 @@ export const tests = {
 			test.equal(linearResult, ease.InOut(amount))
 		}
 		compareWithLinear(ease1, 0)
-		compareWithLinear(easeMinus, 0)
 		compareWithLinear(ease1, 0.25)
-		compareWithLinear(easeMinus, 0.25)
 		compareWithLinear(ease1, 0.5)
-		compareWithLinear(easeMinus, 0.5)
 		compareWithLinear(ease1, 0.75)
-		compareWithLinear(easeMinus, 0.75)
 		compareWithLinear(ease1, 1)
-		compareWithLinear(easeMinus, 1)
-
 		compareWithLinear(ease1, -1)
-		compareWithLinear(easeMinus, -1)
 		compareWithLinear(ease1, Infinity)
-		compareWithLinear(easeMinus, Infinity)
 
 		test.done()
 	},
@@ -2061,6 +2052,7 @@ export const tests = {
 			test.equal(ease.Out(1.0), 1.0)
 		}
 		checkEdgeValue(TWEEN.Easing.generatePow(Number.NEGATIVE_INFINITY))
+		checkEdgeValue(TWEEN.Easing.generatePow(-1.0))
 		checkEdgeValue(TWEEN.Easing.generatePow(1))
 		checkEdgeValue(TWEEN.Easing.generatePow(Math.LOG2E))
 		checkEdgeValue(TWEEN.Easing.generatePow(Math.PI))

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1917,6 +1917,58 @@ export const tests = {
 
 		test.done()
 	},
+
+	'Test TWEEN.Easing.generatePow(1) equals Linear'(test: Test): void {
+		const ease1 = TWEEN.Easing.generatePow(1)
+		const easeMinus = TWEEN.Easing.generatePow(-1)
+
+		const compareWithLinear = (ease: EasingFunctionGroup, amount: number) => {
+			const linearResult = TWEEN.Easing.Linear.None(amount)
+			test.equal(linearResult, ease.In(amount))
+			test.equal(linearResult, ease.Out(amount))
+			test.equal(linearResult, ease.InOut(amount))
+		}
+		compareWithLinear(ease1, 0)
+		compareWithLinear(easeMinus, 0)
+		compareWithLinear(ease1, 0.25)
+		compareWithLinear(easeMinus, 0.25)
+		compareWithLinear(ease1, 0.5)
+		compareWithLinear(easeMinus, 0.5)
+		compareWithLinear(ease1, 0.75)
+		compareWithLinear(easeMinus, 0.75)
+		compareWithLinear(ease1, 1)
+		compareWithLinear(easeMinus, 1)
+
+		compareWithLinear(ease1, -1)
+		compareWithLinear(easeMinus, -1)
+		compareWithLinear(ease1, Infinity)
+		compareWithLinear(easeMinus, Infinity)
+
+		test.done()
+	},
+
+	'Test TWEEN.Easing.generatePow(n) should pass 0.0, 0.5, 1.0'(test: Test): void {
+		const checkEdgeValue = (ease: EasingFunctionGroup) => {
+			test.equal(ease.InOut(0.0), 0.0)
+			test.equal(ease.In(0.0), 0.0)
+			test.equal(ease.Out(0.0), 0.0)
+
+			test.equal(ease.InOut(0.5), 0.5)
+
+			test.equal(ease.InOut(1.0), 1.0)
+			test.equal(ease.In(1.0), 1.0)
+			test.equal(ease.Out(1.0), 1.0)
+		}
+		checkEdgeValue(TWEEN.Easing.generatePow(Number.NEGATIVE_INFINITY))
+		checkEdgeValue(TWEEN.Easing.generatePow(1))
+		checkEdgeValue(TWEEN.Easing.generatePow(Math.LOG2E))
+		checkEdgeValue(TWEEN.Easing.generatePow(Math.PI))
+		checkEdgeValue(TWEEN.Easing.generatePow())
+		checkEdgeValue(TWEEN.Easing.generatePow(6))
+		checkEdgeValue(TWEEN.Easing.generatePow(Number.POSITIVE_INFINITY))
+
+		test.done()
+	},
 }
 
 type Test = {
@@ -1925,4 +1977,10 @@ type Test = {
 	deepEqual(a: unknown, b: unknown, failMessage?: string): void
 	expect(n: number): void
 	done(): void
+}
+
+type EasingFunctionGroup = {
+	In(amount: number): number
+	Out(amount: number): number
+	InOut(amount: number): number
 }

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1968,6 +1968,9 @@ export const tests = {
 		checkEdgeValue(TWEEN.Easing.generatePow(6))
 		checkEdgeValue(TWEEN.Easing.generatePow(Number.POSITIVE_INFINITY))
 
+		test.done()
+	},
+
 	'Test TWEEN.Tween.update() with no arguments'(test: Test): void {
 		const clock = FakeTimers.install()
 		const targetNow = {x: 0.0}


### PR DESCRIPTION
## Related Issues

- tween jumps (jitters) to the final value at the end of animation #116

## Purpose of this Pull Request

This PR is for adding an easing function that has no jitter and a sharp curve like `TWEEN.Easing.Exponential`.

## Details of the changes

1.  Added `TWEEN.Easing.generatePow()` function.
2. Added test cases.
3. Added example page.

`TWEEN.Easing.generatePow()` function the changes sharpness of a curve depending on `power` argument. This approach is the same as the [expo easing function](https://github.com/Popmotion/popmotion/blob/a1903c808757b31d26d876dc2d8d3dea2d131c12/packages/popmotion/src/easing/utils.ts#L14) in [popmotion](https://github.com/Popmotion/popmotion).

[GSAP](https://greensock.com/docs/v3/Eases) calls the similar easing function Power1 ~ 4. Also, [CreateJS/TweenJS](https://github.com/CreateJS/TweenJS) internally calls this easing function [getPowIn, Out, InOut](https://github.com/CreateJS/TweenJS/blob/6df2b9ce7e68d3d824cc490b67cab2bc3204810a/src/tweenjs/Ease.js#L105). Following these precedents, I named this function generatePow.
