### PR TITLE
fix(package.json): add export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
 	"types": "dist/tween.d.ts",
 	"module": "dist/tween.esm.js",
 	"exports": {
-    		".": {
-      			"import": "./dist/tween.esm.js",
-      			"require": "./dist/tween.cjs.js"
-    		}
-  	},
+		".": {
+			"import": "./dist/tween.esm.js",
+			"require": "./dist/tween.cjs.js"
+		}
+	},
 	"files": [
 		"dist",
 		"README.md",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
 	"main": "dist/tween.cjs.js",
 	"types": "dist/tween.d.ts",
 	"module": "dist/tween.esm.js",
+	"exports": {
+    		".": {
+      			"import": "./dist/tween.esm.js",
+      			"require": "./dist/tween.cjs.js"
+    		}
+  	},
 	"files": [
 		"dist",
 		"README.md",


### PR DESCRIPTION
Running ESM in jest tests (node) isn't working properly with this lib yielding this error:
![image](https://user-images.githubusercontent.com/6595726/236420424-72a7b6e4-ecb2-40a0-90bd-e04a8bc02662.png)

Running [@skypack/package-check](https://www.npmjs.com/package/@skypack/package-check) also validates this.
![image](https://user-images.githubusercontent.com/6595726/236417600-a6fcbc38-1322-4aa3-8f6b-35fa6f84b496.png)

This PR adds export map and after these changes everything is healthy:
![image](https://user-images.githubusercontent.com/6595726/236419765-ae2b6b22-54a2-4b6a-a435-040ddd785bdf.png)

Package.json `"module"` is legacy and can (and probably should) be removed. You can also concider adding `"type": "module"` to properly indicate that this lib is ESM, but again, I'll leave this to the maintainer to decide.

This may also fix: https://github.com/tweenjs/tween.js/issues/649 