### PR TITLE
docs: update tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ import * as TWEEN from '@tweenjs/tween.js'
 
 - [User guide](./docs/user_guide.md)
 - [Contributor guide](./docs/contributor_guide.md)
-- [Tutorial](http://learningthreejs.com/blog/2011/08/17/tweenjs-for-smooth-animation/) using tween.js with three.js
+- [Tutorial](https://web.archive.org/web/20220601192930/http://learningthreejs.com/blog/2011/08/17/tweenjs-for-smooth-animation/) using tween.js with three.js
 - Also: [libtween](https://github.com/jsm174/libtween), a port of tween.js to C by [jsm174](https://github.com/jsm174)
 - [Understanding tween.js](https://mikebolt.me/article/understanding-tweenjs.html)
 


### PR DESCRIPTION
The tutorial in the README now redirects to a page to buy Instagram likes. I tend to think that’s not the expected tutorial, so I replaced it with the archived version.