### PR TITLE
change maintainers list and remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ import * as TWEEN from '@tweenjs/tween.js'
 - [Contributor guide](./docs/contributor_guide.md)
 - [Tutorial](https://web.archive.org/web/20220601192930/http://learningthreejs.com/blog/2011/08/17/tweenjs-for-smooth-animation/) using tween.js with three.js
 - Also: [libtween](https://github.com/jsm174/libtween), a port of tween.js to C by [jsm174](https://github.com/jsm174)
-- [Understanding tween.js](https://mikebolt.me/article/understanding-tweenjs.html)
 
 # Examples
 
@@ -369,7 +368,7 @@ If you want to add any feature or change existing features, you _must_ run the t
 
 # People
 
-Maintainers: [mikebolt](https://github.com/mikebolt), [sole](https://github.com/sole), [Joe Pea (@trusktr)](https://github.com/trusktr).
+Maintainers: [Joe Pea (@trusktr)](https://github.com/trusktr).
 
 [All contributors](http://github.com/tweenjs/tween.js/contributors).
 


### PR DESCRIPTION
My old personal site has been down for a while, so the link to the article I wrote is a dead link. I *might* have a backup of the article somewhere but I'm not sure.

Myself and sole are no longer maintaining this project.