### PR TITLE
fix: Use type definition in ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/tween.esm.js",
-			"require": "./dist/tween.cjs.js"
+			"require": "./dist/tween.cjs.js",
+			"types": "./dist/tween.d.ts"
 		}
 	},
 	"files": [


### PR DESCRIPTION
I noticed type definition isn't used when I specify `"type": "module"` in package.json. So I fixed this issue.