### PR TITLE
fix: when yoyo repeats, first frame behaves as if yoyo=false

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -678,13 +678,11 @@ define(['exports'], (function (exports) { 'use strict';
          * it is still playing, just paused).
          */
         Tween.prototype.update = function (time, autoStart) {
-            var _this = this;
             var _a;
             if (time === void 0) { time = now(); }
             if (autoStart === void 0) { autoStart = true; }
             if (this._isPaused)
                 return true;
-            var property;
             var endTime = this._startTime + this._duration;
             if (!this._goToEnd && !this._isPlaying) {
                 if (time > endTime)
@@ -711,84 +709,31 @@ define(['exports'], (function (exports) { 'use strict';
             var elapsedTime = time - this._startTime;
             var durationAndDelay = this._duration + ((_a = this._repeatDelayTime) !== null && _a !== void 0 ? _a : this._delayTime);
             var totalTime = this._duration + this._repeat * durationAndDelay;
-            var calculateElapsedPortion = function () {
-                if (_this._duration === 0)
-                    return 1;
-                if (elapsedTime > totalTime) {
-                    return 1;
-                }
-                var timesRepeated = Math.trunc(elapsedTime / durationAndDelay);
-                var timeIntoCurrentRepeat = elapsedTime - timesRepeated * durationAndDelay;
-                // TODO use %?
-                // const timeIntoCurrentRepeat = elapsedTime % durationAndDelay
-                var portion = Math.min(timeIntoCurrentRepeat / _this._duration, 1);
-                if (portion === 0 && elapsedTime === _this._duration) {
-                    return 1;
-                }
-                return portion;
-            };
-            var repeated = false;
-            var completed = false;
-            var checkStillPlayingAndReverse = function () {
-                if (_this._duration === 0 || elapsedTime >= _this._duration) {
-                    if (_this._repeat > 0) {
-                        var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
-                        if (isFinite(_this._repeat)) {
-                            _this._repeat -= completeCount;
-                        }
-                        // Reassign starting values, restart by making startTime = now
-                        for (property in _this._valuesStartRepeat) {
-                            if (!_this._yoyo && typeof _this._valuesEnd[property] === 'string') {
-                                _this._valuesStartRepeat[property] =
-                                    // eslint-disable-next-line
-                                    // @ts-ignore FIXME?
-                                    _this._valuesStartRepeat[property] + parseFloat(_this._valuesEnd[property]);
-                            }
-                            if (_this._yoyo) {
-                                _this._swapEndStartRepeatValues(property);
-                            }
-                            _this._valuesStart[property] = _this._valuesStartRepeat[property];
-                        }
-                        if (_this._yoyo) {
-                            _this._reversed = !_this._reversed;
-                        }
-                        _this._startTime += durationAndDelay * completeCount;
-                        repeated = true;
-                        return true;
-                    }
-                    else {
-                        completed = true;
-                        return false;
-                    }
-                }
-                return true;
-            };
-            var doUpdates = function () {
-                var elapsed = calculateElapsedPortion();
-                var value = _this._easingFunction(elapsed);
-                // properties transformations
-                _this._updateProperties(_this._object, _this._valuesStart, _this._valuesEnd, value);
-                if (_this._onUpdateCallback) {
-                    _this._onUpdateCallback(_this._object, elapsed);
-                }
-            };
-            var stillPlaying;
-            if (elapsedTime <= this._duration) {
-                doUpdates();
-                stillPlaying = checkStillPlayingAndReverse();
+            var elapsed = this._calculateElapsedPortion(elapsedTime, durationAndDelay, totalTime);
+            var value = this._easingFunction(elapsed);
+            var status = this._calculateCompletionStatus(elapsedTime, durationAndDelay);
+            if (status === 'repeat') {
+                // the current update is happening after the instant the tween repeated
+                this._processRepetition(elapsedTime, durationAndDelay);
             }
-            else {
-                stillPlaying = checkStillPlayingAndReverse();
-                doUpdates();
+            this._updateProperties(this._object, this._valuesStart, this._valuesEnd, value);
+            if (status === 'about-to-repeat') {
+                // the current update is happening at the exact instant the tween is going to repeat
+                // the values should match the end of the tween, not the beginning,
+                // that's why _processRepetition happens after _updateProperties
+                this._processRepetition(elapsedTime, durationAndDelay);
             }
-            if (repeated) {
+            if (this._onUpdateCallback) {
+                this._onUpdateCallback(this._object, elapsed);
+            }
+            if (status === 'repeat' || status === 'about-to-repeat') {
                 if (this._onRepeatCallback) {
                     this._onRepeatCallback(this._object);
                 }
                 this._onEveryStartCallbackFired = false;
             }
-            if (completed) {
-                completed = true;
+            else if (status === 'completed') {
+                this._isPlaying = false;
                 if (this._onCompleteCallback) {
                     this._onCompleteCallback(this._object);
                 }
@@ -797,9 +742,52 @@ define(['exports'], (function (exports) { 'use strict';
                     // even if the `update()` method was called way past the duration of the tween
                     this._chainedTweens[i].start(this._startTime + this._duration, false);
                 }
-                this._isPlaying = false;
             }
-            return stillPlaying;
+            return status !== 'completed';
+        };
+        Tween.prototype._calculateElapsedPortion = function (elapsedTime, durationAndDelay, totalTime) {
+            if (this._duration === 0 || elapsedTime > totalTime) {
+                return 1;
+            }
+            var timeIntoCurrentRepeat = elapsedTime % durationAndDelay;
+            var portion = Math.min(timeIntoCurrentRepeat / this._duration, 1);
+            if (portion === 0 && elapsedTime !== 0 && elapsedTime % this._duration === 0) {
+                return 1;
+            }
+            return portion;
+        };
+        Tween.prototype._calculateCompletionStatus = function (elapsedTime, durationAndDelay) {
+            if (this._duration !== 0 && elapsedTime < this._duration) {
+                return 'playing';
+            }
+            if (this._repeat <= 0) {
+                return 'completed';
+            }
+            if (elapsedTime === this._duration) {
+                return 'about-to-repeat';
+            }
+            return 'repeat';
+        };
+        Tween.prototype._processRepetition = function (elapsedTime, durationAndDelay) {
+            var completeCount = Math.min(Math.trunc((elapsedTime - this._duration) / durationAndDelay) + 1, this._repeat);
+            if (isFinite(this._repeat)) {
+                this._repeat -= completeCount;
+            }
+            // Reassign starting values, restart by making startTime = now
+            for (var property in this._valuesStartRepeat) {
+                var valueEnd = this._valuesEnd[property];
+                if (!this._yoyo && typeof valueEnd === 'string') {
+                    this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(valueEnd);
+                }
+                if (this._yoyo) {
+                    this._swapEndStartRepeatValues(property);
+                }
+                this._valuesStart[property] = this._valuesStartRepeat[property];
+            }
+            if (this._yoyo) {
+                this._reversed = !this._reversed;
+            }
+            this._startTime += durationAndDelay * completeCount;
         };
         Tween.prototype._updateProperties = function (_object, _valuesStart, _valuesEnd, value) {
             for (var property in _valuesEnd) {

--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -727,56 +727,71 @@ define(['exports'], (function (exports) { 'use strict';
                 }
                 return portion;
             };
-            var elapsed = calculateElapsedPortion();
-            var value = this._easingFunction(elapsed);
-            // properties transformations
-            this._updateProperties(this._object, this._valuesStart, this._valuesEnd, value);
-            if (this._onUpdateCallback) {
-                this._onUpdateCallback(this._object, elapsed);
-            }
-            if (this._duration === 0 || elapsedTime >= this._duration) {
-                if (this._repeat > 0) {
-                    var completeCount = Math.min(Math.trunc((elapsedTime - this._duration) / durationAndDelay) + 1, this._repeat);
-                    if (isFinite(this._repeat)) {
-                        this._repeat -= completeCount;
-                    }
-                    // Reassign starting values, restart by making startTime = now
-                    for (property in this._valuesStartRepeat) {
-                        if (!this._yoyo && typeof this._valuesEnd[property] === 'string') {
-                            this._valuesStartRepeat[property] =
-                                // eslint-disable-next-line
-                                // @ts-ignore FIXME?
-                                this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property]);
+            var checkStillPlaying = function () {
+                if (_this._duration === 0 || elapsedTime >= _this._duration) {
+                    if (_this._repeat > 0) {
+                        var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
+                        if (isFinite(_this._repeat)) {
+                            _this._repeat -= completeCount;
                         }
-                        if (this._yoyo) {
-                            this._swapEndStartRepeatValues(property);
+                        // Reassign starting values, restart by making startTime = now
+                        for (property in _this._valuesStartRepeat) {
+                            if (!_this._yoyo && typeof _this._valuesEnd[property] === 'string') {
+                                _this._valuesStartRepeat[property] =
+                                    // eslint-disable-next-line
+                                    // @ts-ignore FIXME?
+                                    _this._valuesStartRepeat[property] + parseFloat(_this._valuesEnd[property]);
+                            }
+                            if (_this._yoyo) {
+                                _this._swapEndStartRepeatValues(property);
+                            }
+                            _this._valuesStart[property] = _this._valuesStartRepeat[property];
                         }
-                        this._valuesStart[property] = this._valuesStartRepeat[property];
+                        if (_this._yoyo) {
+                            _this._reversed = !_this._reversed;
+                        }
+                        _this._startTime += durationAndDelay * completeCount;
+                        if (_this._onRepeatCallback) {
+                            _this._onRepeatCallback(_this._object);
+                        }
+                        _this._onEveryStartCallbackFired = false;
+                        return true;
                     }
-                    if (this._yoyo) {
-                        this._reversed = !this._reversed;
+                    else {
+                        if (_this._onCompleteCallback) {
+                            _this._onCompleteCallback(_this._object);
+                        }
+                        for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
+                            // Make the chained tweens start exactly at the time they should,
+                            // even if the `update()` method was called way past the duration of the tween
+                            _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
+                        }
+                        _this._isPlaying = false;
+                        return false;
                     }
-                    this._startTime += durationAndDelay * completeCount;
-                    if (this._onRepeatCallback) {
-                        this._onRepeatCallback(this._object);
-                    }
-                    this._onEveryStartCallbackFired = false;
-                    return true;
                 }
-                else {
-                    if (this._onCompleteCallback) {
-                        this._onCompleteCallback(this._object);
-                    }
-                    for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
-                        // Make the chained tweens start exactly at the time they should,
-                        // even if the `update()` method was called way past the duration of the tween
-                        this._chainedTweens[i].start(this._startTime + this._duration, false);
-                    }
-                    this._isPlaying = false;
-                    return false;
+                return true;
+            };
+            var doUpdates = function () {
+                var elapsed = calculateElapsedPortion();
+                var value = _this._easingFunction(elapsed);
+                // properties transformations
+                _this._updateProperties(_this._object, _this._valuesStart, _this._valuesEnd, value);
+                if (_this._onUpdateCallback) {
+                    _this._onUpdateCallback(_this._object, elapsed);
                 }
+            };
+            var stillPlaying;
+            // if (true) {
+            if (elapsedTime <= this._duration) {
+                doUpdates();
+                stillPlaying = checkStillPlaying();
             }
-            return true;
+            else {
+                stillPlaying = checkStillPlaying();
+                doUpdates();
+            }
+            return stillPlaying;
         };
         Tween.prototype._updateProperties = function (_object, _valuesStart, _valuesEnd, value) {
             for (var property in _valuesEnd) {

--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -727,7 +727,9 @@ define(['exports'], (function (exports) { 'use strict';
                 }
                 return portion;
             };
-            var checkStillPlaying = function () {
+            var repeated = false;
+            var completed = false;
+            var checkStillPlayingAndReverse = function () {
                 if (_this._duration === 0 || elapsedTime >= _this._duration) {
                     if (_this._repeat > 0) {
                         var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
@@ -751,22 +753,11 @@ define(['exports'], (function (exports) { 'use strict';
                             _this._reversed = !_this._reversed;
                         }
                         _this._startTime += durationAndDelay * completeCount;
-                        if (_this._onRepeatCallback) {
-                            _this._onRepeatCallback(_this._object);
-                        }
-                        _this._onEveryStartCallbackFired = false;
+                        repeated = true;
                         return true;
                     }
                     else {
-                        if (_this._onCompleteCallback) {
-                            _this._onCompleteCallback(_this._object);
-                        }
-                        for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
-                            // Make the chained tweens start exactly at the time they should,
-                            // even if the `update()` method was called way past the duration of the tween
-                            _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
-                        }
-                        _this._isPlaying = false;
+                        completed = true;
                         return false;
                     }
                 }
@@ -782,14 +773,31 @@ define(['exports'], (function (exports) { 'use strict';
                 }
             };
             var stillPlaying;
-            // if (true) {
             if (elapsedTime <= this._duration) {
                 doUpdates();
-                stillPlaying = checkStillPlaying();
+                stillPlaying = checkStillPlayingAndReverse();
             }
             else {
-                stillPlaying = checkStillPlaying();
+                stillPlaying = checkStillPlayingAndReverse();
                 doUpdates();
+            }
+            if (repeated) {
+                if (this._onRepeatCallback) {
+                    this._onRepeatCallback(this._object);
+                }
+                this._onEveryStartCallbackFired = false;
+            }
+            if (completed) {
+                completed = true;
+                if (this._onCompleteCallback) {
+                    this._onCompleteCallback(this._object);
+                }
+                for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
+                    // Make the chained tweens start exactly at the time they should,
+                    // even if the `update()` method was called way past the duration of the tween
+                    this._chainedTweens[i].start(this._startTime + this._duration, false);
+                }
+                this._isPlaying = false;
             }
             return stillPlaying;
         };

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -729,7 +729,9 @@ var Tween = /** @class */ (function () {
             }
             return portion;
         };
-        var checkStillPlaying = function () {
+        var repeated = false;
+        var completed = false;
+        var checkStillPlayingAndReverse = function () {
             if (_this._duration === 0 || elapsedTime >= _this._duration) {
                 if (_this._repeat > 0) {
                     var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
@@ -753,22 +755,11 @@ var Tween = /** @class */ (function () {
                         _this._reversed = !_this._reversed;
                     }
                     _this._startTime += durationAndDelay * completeCount;
-                    if (_this._onRepeatCallback) {
-                        _this._onRepeatCallback(_this._object);
-                    }
-                    _this._onEveryStartCallbackFired = false;
+                    repeated = true;
                     return true;
                 }
                 else {
-                    if (_this._onCompleteCallback) {
-                        _this._onCompleteCallback(_this._object);
-                    }
-                    for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
-                        // Make the chained tweens start exactly at the time they should,
-                        // even if the `update()` method was called way past the duration of the tween
-                        _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
-                    }
-                    _this._isPlaying = false;
+                    completed = true;
                     return false;
                 }
             }
@@ -784,14 +775,31 @@ var Tween = /** @class */ (function () {
             }
         };
         var stillPlaying;
-        // if (true) {
         if (elapsedTime <= this._duration) {
             doUpdates();
-            stillPlaying = checkStillPlaying();
+            stillPlaying = checkStillPlayingAndReverse();
         }
         else {
-            stillPlaying = checkStillPlaying();
+            stillPlaying = checkStillPlayingAndReverse();
             doUpdates();
+        }
+        if (repeated) {
+            if (this._onRepeatCallback) {
+                this._onRepeatCallback(this._object);
+            }
+            this._onEveryStartCallbackFired = false;
+        }
+        if (completed) {
+            completed = true;
+            if (this._onCompleteCallback) {
+                this._onCompleteCallback(this._object);
+            }
+            for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
+                // Make the chained tweens start exactly at the time they should,
+                // even if the `update()` method was called way past the duration of the tween
+                this._chainedTweens[i].start(this._startTime + this._duration, false);
+            }
+            this._isPlaying = false;
         }
         return stillPlaying;
     };

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -680,13 +680,11 @@ var Tween = /** @class */ (function () {
      * it is still playing, just paused).
      */
     Tween.prototype.update = function (time, autoStart) {
-        var _this = this;
         var _a;
         if (time === void 0) { time = now(); }
         if (autoStart === void 0) { autoStart = true; }
         if (this._isPaused)
             return true;
-        var property;
         var endTime = this._startTime + this._duration;
         if (!this._goToEnd && !this._isPlaying) {
             if (time > endTime)
@@ -713,84 +711,31 @@ var Tween = /** @class */ (function () {
         var elapsedTime = time - this._startTime;
         var durationAndDelay = this._duration + ((_a = this._repeatDelayTime) !== null && _a !== void 0 ? _a : this._delayTime);
         var totalTime = this._duration + this._repeat * durationAndDelay;
-        var calculateElapsedPortion = function () {
-            if (_this._duration === 0)
-                return 1;
-            if (elapsedTime > totalTime) {
-                return 1;
-            }
-            var timesRepeated = Math.trunc(elapsedTime / durationAndDelay);
-            var timeIntoCurrentRepeat = elapsedTime - timesRepeated * durationAndDelay;
-            // TODO use %?
-            // const timeIntoCurrentRepeat = elapsedTime % durationAndDelay
-            var portion = Math.min(timeIntoCurrentRepeat / _this._duration, 1);
-            if (portion === 0 && elapsedTime === _this._duration) {
-                return 1;
-            }
-            return portion;
-        };
-        var repeated = false;
-        var completed = false;
-        var checkStillPlayingAndReverse = function () {
-            if (_this._duration === 0 || elapsedTime >= _this._duration) {
-                if (_this._repeat > 0) {
-                    var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
-                    if (isFinite(_this._repeat)) {
-                        _this._repeat -= completeCount;
-                    }
-                    // Reassign starting values, restart by making startTime = now
-                    for (property in _this._valuesStartRepeat) {
-                        if (!_this._yoyo && typeof _this._valuesEnd[property] === 'string') {
-                            _this._valuesStartRepeat[property] =
-                                // eslint-disable-next-line
-                                // @ts-ignore FIXME?
-                                _this._valuesStartRepeat[property] + parseFloat(_this._valuesEnd[property]);
-                        }
-                        if (_this._yoyo) {
-                            _this._swapEndStartRepeatValues(property);
-                        }
-                        _this._valuesStart[property] = _this._valuesStartRepeat[property];
-                    }
-                    if (_this._yoyo) {
-                        _this._reversed = !_this._reversed;
-                    }
-                    _this._startTime += durationAndDelay * completeCount;
-                    repeated = true;
-                    return true;
-                }
-                else {
-                    completed = true;
-                    return false;
-                }
-            }
-            return true;
-        };
-        var doUpdates = function () {
-            var elapsed = calculateElapsedPortion();
-            var value = _this._easingFunction(elapsed);
-            // properties transformations
-            _this._updateProperties(_this._object, _this._valuesStart, _this._valuesEnd, value);
-            if (_this._onUpdateCallback) {
-                _this._onUpdateCallback(_this._object, elapsed);
-            }
-        };
-        var stillPlaying;
-        if (elapsedTime <= this._duration) {
-            doUpdates();
-            stillPlaying = checkStillPlayingAndReverse();
+        var elapsed = this._calculateElapsedPortion(elapsedTime, durationAndDelay, totalTime);
+        var value = this._easingFunction(elapsed);
+        var status = this._calculateCompletionStatus(elapsedTime, durationAndDelay);
+        if (status === 'repeat') {
+            // the current update is happening after the instant the tween repeated
+            this._processRepetition(elapsedTime, durationAndDelay);
         }
-        else {
-            stillPlaying = checkStillPlayingAndReverse();
-            doUpdates();
+        this._updateProperties(this._object, this._valuesStart, this._valuesEnd, value);
+        if (status === 'about-to-repeat') {
+            // the current update is happening at the exact instant the tween is going to repeat
+            // the values should match the end of the tween, not the beginning,
+            // that's why _processRepetition happens after _updateProperties
+            this._processRepetition(elapsedTime, durationAndDelay);
         }
-        if (repeated) {
+        if (this._onUpdateCallback) {
+            this._onUpdateCallback(this._object, elapsed);
+        }
+        if (status === 'repeat' || status === 'about-to-repeat') {
             if (this._onRepeatCallback) {
                 this._onRepeatCallback(this._object);
             }
             this._onEveryStartCallbackFired = false;
         }
-        if (completed) {
-            completed = true;
+        else if (status === 'completed') {
+            this._isPlaying = false;
             if (this._onCompleteCallback) {
                 this._onCompleteCallback(this._object);
             }
@@ -799,9 +744,52 @@ var Tween = /** @class */ (function () {
                 // even if the `update()` method was called way past the duration of the tween
                 this._chainedTweens[i].start(this._startTime + this._duration, false);
             }
-            this._isPlaying = false;
         }
-        return stillPlaying;
+        return status !== 'completed';
+    };
+    Tween.prototype._calculateElapsedPortion = function (elapsedTime, durationAndDelay, totalTime) {
+        if (this._duration === 0 || elapsedTime > totalTime) {
+            return 1;
+        }
+        var timeIntoCurrentRepeat = elapsedTime % durationAndDelay;
+        var portion = Math.min(timeIntoCurrentRepeat / this._duration, 1);
+        if (portion === 0 && elapsedTime !== 0 && elapsedTime % this._duration === 0) {
+            return 1;
+        }
+        return portion;
+    };
+    Tween.prototype._calculateCompletionStatus = function (elapsedTime, durationAndDelay) {
+        if (this._duration !== 0 && elapsedTime < this._duration) {
+            return 'playing';
+        }
+        if (this._repeat <= 0) {
+            return 'completed';
+        }
+        if (elapsedTime === this._duration) {
+            return 'about-to-repeat';
+        }
+        return 'repeat';
+    };
+    Tween.prototype._processRepetition = function (elapsedTime, durationAndDelay) {
+        var completeCount = Math.min(Math.trunc((elapsedTime - this._duration) / durationAndDelay) + 1, this._repeat);
+        if (isFinite(this._repeat)) {
+            this._repeat -= completeCount;
+        }
+        // Reassign starting values, restart by making startTime = now
+        for (var property in this._valuesStartRepeat) {
+            var valueEnd = this._valuesEnd[property];
+            if (!this._yoyo && typeof valueEnd === 'string') {
+                this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(valueEnd);
+            }
+            if (this._yoyo) {
+                this._swapEndStartRepeatValues(property);
+            }
+            this._valuesStart[property] = this._valuesStartRepeat[property];
+        }
+        if (this._yoyo) {
+            this._reversed = !this._reversed;
+        }
+        this._startTime += durationAndDelay * completeCount;
     };
     Tween.prototype._updateProperties = function (_object, _valuesStart, _valuesEnd, value) {
         for (var property in _valuesEnd) {

--- a/dist/tween.d.ts
+++ b/dist/tween.d.ts
@@ -137,6 +137,9 @@ declare class Tween<T extends UnknownProps> {
      * it is still playing, just paused).
      */
     update(time?: number, autoStart?: boolean): boolean;
+    private _calculateElapsedPortion;
+    private _calculateCompletionStatus;
+    private _processRepetition;
     private _updateProperties;
     private _handleRelativeValue;
     private _swapEndStartRepeatValues;

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -725,7 +725,9 @@ var Tween = /** @class */ (function () {
             }
             return portion;
         };
-        var checkStillPlaying = function () {
+        var repeated = false;
+        var completed = false;
+        var checkStillPlayingAndReverse = function () {
             if (_this._duration === 0 || elapsedTime >= _this._duration) {
                 if (_this._repeat > 0) {
                     var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
@@ -749,22 +751,11 @@ var Tween = /** @class */ (function () {
                         _this._reversed = !_this._reversed;
                     }
                     _this._startTime += durationAndDelay * completeCount;
-                    if (_this._onRepeatCallback) {
-                        _this._onRepeatCallback(_this._object);
-                    }
-                    _this._onEveryStartCallbackFired = false;
+                    repeated = true;
                     return true;
                 }
                 else {
-                    if (_this._onCompleteCallback) {
-                        _this._onCompleteCallback(_this._object);
-                    }
-                    for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
-                        // Make the chained tweens start exactly at the time they should,
-                        // even if the `update()` method was called way past the duration of the tween
-                        _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
-                    }
-                    _this._isPlaying = false;
+                    completed = true;
                     return false;
                 }
             }
@@ -780,14 +771,31 @@ var Tween = /** @class */ (function () {
             }
         };
         var stillPlaying;
-        // if (true) {
         if (elapsedTime <= this._duration) {
             doUpdates();
-            stillPlaying = checkStillPlaying();
+            stillPlaying = checkStillPlayingAndReverse();
         }
         else {
-            stillPlaying = checkStillPlaying();
+            stillPlaying = checkStillPlayingAndReverse();
             doUpdates();
+        }
+        if (repeated) {
+            if (this._onRepeatCallback) {
+                this._onRepeatCallback(this._object);
+            }
+            this._onEveryStartCallbackFired = false;
+        }
+        if (completed) {
+            completed = true;
+            if (this._onCompleteCallback) {
+                this._onCompleteCallback(this._object);
+            }
+            for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
+                // Make the chained tweens start exactly at the time they should,
+                // even if the `update()` method was called way past the duration of the tween
+                this._chainedTweens[i].start(this._startTime + this._duration, false);
+            }
+            this._isPlaying = false;
         }
         return stillPlaying;
     };

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -725,56 +725,71 @@ var Tween = /** @class */ (function () {
             }
             return portion;
         };
-        var elapsed = calculateElapsedPortion();
-        var value = this._easingFunction(elapsed);
-        // properties transformations
-        this._updateProperties(this._object, this._valuesStart, this._valuesEnd, value);
-        if (this._onUpdateCallback) {
-            this._onUpdateCallback(this._object, elapsed);
-        }
-        if (this._duration === 0 || elapsedTime >= this._duration) {
-            if (this._repeat > 0) {
-                var completeCount = Math.min(Math.trunc((elapsedTime - this._duration) / durationAndDelay) + 1, this._repeat);
-                if (isFinite(this._repeat)) {
-                    this._repeat -= completeCount;
-                }
-                // Reassign starting values, restart by making startTime = now
-                for (property in this._valuesStartRepeat) {
-                    if (!this._yoyo && typeof this._valuesEnd[property] === 'string') {
-                        this._valuesStartRepeat[property] =
-                            // eslint-disable-next-line
-                            // @ts-ignore FIXME?
-                            this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property]);
+        var checkStillPlaying = function () {
+            if (_this._duration === 0 || elapsedTime >= _this._duration) {
+                if (_this._repeat > 0) {
+                    var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
+                    if (isFinite(_this._repeat)) {
+                        _this._repeat -= completeCount;
                     }
-                    if (this._yoyo) {
-                        this._swapEndStartRepeatValues(property);
+                    // Reassign starting values, restart by making startTime = now
+                    for (property in _this._valuesStartRepeat) {
+                        if (!_this._yoyo && typeof _this._valuesEnd[property] === 'string') {
+                            _this._valuesStartRepeat[property] =
+                                // eslint-disable-next-line
+                                // @ts-ignore FIXME?
+                                _this._valuesStartRepeat[property] + parseFloat(_this._valuesEnd[property]);
+                        }
+                        if (_this._yoyo) {
+                            _this._swapEndStartRepeatValues(property);
+                        }
+                        _this._valuesStart[property] = _this._valuesStartRepeat[property];
                     }
-                    this._valuesStart[property] = this._valuesStartRepeat[property];
+                    if (_this._yoyo) {
+                        _this._reversed = !_this._reversed;
+                    }
+                    _this._startTime += durationAndDelay * completeCount;
+                    if (_this._onRepeatCallback) {
+                        _this._onRepeatCallback(_this._object);
+                    }
+                    _this._onEveryStartCallbackFired = false;
+                    return true;
                 }
-                if (this._yoyo) {
-                    this._reversed = !this._reversed;
+                else {
+                    if (_this._onCompleteCallback) {
+                        _this._onCompleteCallback(_this._object);
+                    }
+                    for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
+                        // Make the chained tweens start exactly at the time they should,
+                        // even if the `update()` method was called way past the duration of the tween
+                        _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
+                    }
+                    _this._isPlaying = false;
+                    return false;
                 }
-                this._startTime += durationAndDelay * completeCount;
-                if (this._onRepeatCallback) {
-                    this._onRepeatCallback(this._object);
-                }
-                this._onEveryStartCallbackFired = false;
-                return true;
             }
-            else {
-                if (this._onCompleteCallback) {
-                    this._onCompleteCallback(this._object);
-                }
-                for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
-                    // Make the chained tweens start exactly at the time they should,
-                    // even if the `update()` method was called way past the duration of the tween
-                    this._chainedTweens[i].start(this._startTime + this._duration, false);
-                }
-                this._isPlaying = false;
-                return false;
+            return true;
+        };
+        var doUpdates = function () {
+            var elapsed = calculateElapsedPortion();
+            var value = _this._easingFunction(elapsed);
+            // properties transformations
+            _this._updateProperties(_this._object, _this._valuesStart, _this._valuesEnd, value);
+            if (_this._onUpdateCallback) {
+                _this._onUpdateCallback(_this._object, elapsed);
             }
+        };
+        var stillPlaying;
+        // if (true) {
+        if (elapsedTime <= this._duration) {
+            doUpdates();
+            stillPlaying = checkStillPlaying();
         }
-        return true;
+        else {
+            stillPlaying = checkStillPlaying();
+            doUpdates();
+        }
+        return stillPlaying;
     };
     Tween.prototype._updateProperties = function (_object, _valuesStart, _valuesEnd, value) {
         for (var property in _valuesEnd) {

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -676,13 +676,11 @@ var Tween = /** @class */ (function () {
      * it is still playing, just paused).
      */
     Tween.prototype.update = function (time, autoStart) {
-        var _this = this;
         var _a;
         if (time === void 0) { time = now(); }
         if (autoStart === void 0) { autoStart = true; }
         if (this._isPaused)
             return true;
-        var property;
         var endTime = this._startTime + this._duration;
         if (!this._goToEnd && !this._isPlaying) {
             if (time > endTime)
@@ -709,84 +707,31 @@ var Tween = /** @class */ (function () {
         var elapsedTime = time - this._startTime;
         var durationAndDelay = this._duration + ((_a = this._repeatDelayTime) !== null && _a !== void 0 ? _a : this._delayTime);
         var totalTime = this._duration + this._repeat * durationAndDelay;
-        var calculateElapsedPortion = function () {
-            if (_this._duration === 0)
-                return 1;
-            if (elapsedTime > totalTime) {
-                return 1;
-            }
-            var timesRepeated = Math.trunc(elapsedTime / durationAndDelay);
-            var timeIntoCurrentRepeat = elapsedTime - timesRepeated * durationAndDelay;
-            // TODO use %?
-            // const timeIntoCurrentRepeat = elapsedTime % durationAndDelay
-            var portion = Math.min(timeIntoCurrentRepeat / _this._duration, 1);
-            if (portion === 0 && elapsedTime === _this._duration) {
-                return 1;
-            }
-            return portion;
-        };
-        var repeated = false;
-        var completed = false;
-        var checkStillPlayingAndReverse = function () {
-            if (_this._duration === 0 || elapsedTime >= _this._duration) {
-                if (_this._repeat > 0) {
-                    var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
-                    if (isFinite(_this._repeat)) {
-                        _this._repeat -= completeCount;
-                    }
-                    // Reassign starting values, restart by making startTime = now
-                    for (property in _this._valuesStartRepeat) {
-                        if (!_this._yoyo && typeof _this._valuesEnd[property] === 'string') {
-                            _this._valuesStartRepeat[property] =
-                                // eslint-disable-next-line
-                                // @ts-ignore FIXME?
-                                _this._valuesStartRepeat[property] + parseFloat(_this._valuesEnd[property]);
-                        }
-                        if (_this._yoyo) {
-                            _this._swapEndStartRepeatValues(property);
-                        }
-                        _this._valuesStart[property] = _this._valuesStartRepeat[property];
-                    }
-                    if (_this._yoyo) {
-                        _this._reversed = !_this._reversed;
-                    }
-                    _this._startTime += durationAndDelay * completeCount;
-                    repeated = true;
-                    return true;
-                }
-                else {
-                    completed = true;
-                    return false;
-                }
-            }
-            return true;
-        };
-        var doUpdates = function () {
-            var elapsed = calculateElapsedPortion();
-            var value = _this._easingFunction(elapsed);
-            // properties transformations
-            _this._updateProperties(_this._object, _this._valuesStart, _this._valuesEnd, value);
-            if (_this._onUpdateCallback) {
-                _this._onUpdateCallback(_this._object, elapsed);
-            }
-        };
-        var stillPlaying;
-        if (elapsedTime <= this._duration) {
-            doUpdates();
-            stillPlaying = checkStillPlayingAndReverse();
+        var elapsed = this._calculateElapsedPortion(elapsedTime, durationAndDelay, totalTime);
+        var value = this._easingFunction(elapsed);
+        var status = this._calculateCompletionStatus(elapsedTime, durationAndDelay);
+        if (status === 'repeat') {
+            // the current update is happening after the instant the tween repeated
+            this._processRepetition(elapsedTime, durationAndDelay);
         }
-        else {
-            stillPlaying = checkStillPlayingAndReverse();
-            doUpdates();
+        this._updateProperties(this._object, this._valuesStart, this._valuesEnd, value);
+        if (status === 'about-to-repeat') {
+            // the current update is happening at the exact instant the tween is going to repeat
+            // the values should match the end of the tween, not the beginning,
+            // that's why _processRepetition happens after _updateProperties
+            this._processRepetition(elapsedTime, durationAndDelay);
         }
-        if (repeated) {
+        if (this._onUpdateCallback) {
+            this._onUpdateCallback(this._object, elapsed);
+        }
+        if (status === 'repeat' || status === 'about-to-repeat') {
             if (this._onRepeatCallback) {
                 this._onRepeatCallback(this._object);
             }
             this._onEveryStartCallbackFired = false;
         }
-        if (completed) {
-            completed = true;
+        else if (status === 'completed') {
+            this._isPlaying = false;
             if (this._onCompleteCallback) {
                 this._onCompleteCallback(this._object);
             }
@@ -795,9 +740,52 @@ var Tween = /** @class */ (function () {
                 // even if the `update()` method was called way past the duration of the tween
                 this._chainedTweens[i].start(this._startTime + this._duration, false);
             }
-            this._isPlaying = false;
         }
-        return stillPlaying;
+        return status !== 'completed';
+    };
+    Tween.prototype._calculateElapsedPortion = function (elapsedTime, durationAndDelay, totalTime) {
+        if (this._duration === 0 || elapsedTime > totalTime) {
+            return 1;
+        }
+        var timeIntoCurrentRepeat = elapsedTime % durationAndDelay;
+        var portion = Math.min(timeIntoCurrentRepeat / this._duration, 1);
+        if (portion === 0 && elapsedTime !== 0 && elapsedTime % this._duration === 0) {
+            return 1;
+        }
+        return portion;
+    };
+    Tween.prototype._calculateCompletionStatus = function (elapsedTime, durationAndDelay) {
+        if (this._duration !== 0 && elapsedTime < this._duration) {
+            return 'playing';
+        }
+        if (this._repeat <= 0) {
+            return 'completed';
+        }
+        if (elapsedTime === this._duration) {
+            return 'about-to-repeat';
+        }
+        return 'repeat';
+    };
+    Tween.prototype._processRepetition = function (elapsedTime, durationAndDelay) {
+        var completeCount = Math.min(Math.trunc((elapsedTime - this._duration) / durationAndDelay) + 1, this._repeat);
+        if (isFinite(this._repeat)) {
+            this._repeat -= completeCount;
+        }
+        // Reassign starting values, restart by making startTime = now
+        for (var property in this._valuesStartRepeat) {
+            var valueEnd = this._valuesEnd[property];
+            if (!this._yoyo && typeof valueEnd === 'string') {
+                this._valuesStartRepeat[property] = this._valuesStartRepeat[property] + parseFloat(valueEnd);
+            }
+            if (this._yoyo) {
+                this._swapEndStartRepeatValues(property);
+            }
+            this._valuesStart[property] = this._valuesStartRepeat[property];
+        }
+        if (this._yoyo) {
+            this._reversed = !this._reversed;
+        }
+        this._startTime += durationAndDelay * completeCount;
     };
     Tween.prototype._updateProperties = function (_object, _valuesStart, _valuesEnd, value) {
         for (var property in _valuesEnd) {

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -731,56 +731,71 @@
                 }
                 return portion;
             };
-            var elapsed = calculateElapsedPortion();
-            var value = this._easingFunction(elapsed);
-            // properties transformations
-            this._updateProperties(this._object, this._valuesStart, this._valuesEnd, value);
-            if (this._onUpdateCallback) {
-                this._onUpdateCallback(this._object, elapsed);
-            }
-            if (this._duration === 0 || elapsedTime >= this._duration) {
-                if (this._repeat > 0) {
-                    var completeCount = Math.min(Math.trunc((elapsedTime - this._duration) / durationAndDelay) + 1, this._repeat);
-                    if (isFinite(this._repeat)) {
-                        this._repeat -= completeCount;
-                    }
-                    // Reassign starting values, restart by making startTime = now
-                    for (property in this._valuesStartRepeat) {
-                        if (!this._yoyo && typeof this._valuesEnd[property] === 'string') {
-                            this._valuesStartRepeat[property] =
-                                // eslint-disable-next-line
-                                // @ts-ignore FIXME?
-                                this._valuesStartRepeat[property] + parseFloat(this._valuesEnd[property]);
+            var checkStillPlaying = function () {
+                if (_this._duration === 0 || elapsedTime >= _this._duration) {
+                    if (_this._repeat > 0) {
+                        var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
+                        if (isFinite(_this._repeat)) {
+                            _this._repeat -= completeCount;
                         }
-                        if (this._yoyo) {
-                            this._swapEndStartRepeatValues(property);
+                        // Reassign starting values, restart by making startTime = now
+                        for (property in _this._valuesStartRepeat) {
+                            if (!_this._yoyo && typeof _this._valuesEnd[property] === 'string') {
+                                _this._valuesStartRepeat[property] =
+                                    // eslint-disable-next-line
+                                    // @ts-ignore FIXME?
+                                    _this._valuesStartRepeat[property] + parseFloat(_this._valuesEnd[property]);
+                            }
+                            if (_this._yoyo) {
+                                _this._swapEndStartRepeatValues(property);
+                            }
+                            _this._valuesStart[property] = _this._valuesStartRepeat[property];
                         }
-                        this._valuesStart[property] = this._valuesStartRepeat[property];
+                        if (_this._yoyo) {
+                            _this._reversed = !_this._reversed;
+                        }
+                        _this._startTime += durationAndDelay * completeCount;
+                        if (_this._onRepeatCallback) {
+                            _this._onRepeatCallback(_this._object);
+                        }
+                        _this._onEveryStartCallbackFired = false;
+                        return true;
                     }
-                    if (this._yoyo) {
-                        this._reversed = !this._reversed;
+                    else {
+                        if (_this._onCompleteCallback) {
+                            _this._onCompleteCallback(_this._object);
+                        }
+                        for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
+                            // Make the chained tweens start exactly at the time they should,
+                            // even if the `update()` method was called way past the duration of the tween
+                            _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
+                        }
+                        _this._isPlaying = false;
+                        return false;
                     }
-                    this._startTime += durationAndDelay * completeCount;
-                    if (this._onRepeatCallback) {
-                        this._onRepeatCallback(this._object);
-                    }
-                    this._onEveryStartCallbackFired = false;
-                    return true;
                 }
-                else {
-                    if (this._onCompleteCallback) {
-                        this._onCompleteCallback(this._object);
-                    }
-                    for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
-                        // Make the chained tweens start exactly at the time they should,
-                        // even if the `update()` method was called way past the duration of the tween
-                        this._chainedTweens[i].start(this._startTime + this._duration, false);
-                    }
-                    this._isPlaying = false;
-                    return false;
+                return true;
+            };
+            var doUpdates = function () {
+                var elapsed = calculateElapsedPortion();
+                var value = _this._easingFunction(elapsed);
+                // properties transformations
+                _this._updateProperties(_this._object, _this._valuesStart, _this._valuesEnd, value);
+                if (_this._onUpdateCallback) {
+                    _this._onUpdateCallback(_this._object, elapsed);
                 }
+            };
+            var stillPlaying;
+            // if (true) {
+            if (elapsedTime <= this._duration) {
+                doUpdates();
+                stillPlaying = checkStillPlaying();
             }
-            return true;
+            else {
+                stillPlaying = checkStillPlaying();
+                doUpdates();
+            }
+            return stillPlaying;
         };
         Tween.prototype._updateProperties = function (_object, _valuesStart, _valuesEnd, value) {
             for (var property in _valuesEnd) {

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -731,7 +731,9 @@
                 }
                 return portion;
             };
-            var checkStillPlaying = function () {
+            var repeated = false;
+            var completed = false;
+            var checkStillPlayingAndReverse = function () {
                 if (_this._duration === 0 || elapsedTime >= _this._duration) {
                     if (_this._repeat > 0) {
                         var completeCount = Math.min(Math.trunc((elapsedTime - _this._duration) / durationAndDelay) + 1, _this._repeat);
@@ -755,22 +757,11 @@
                             _this._reversed = !_this._reversed;
                         }
                         _this._startTime += durationAndDelay * completeCount;
-                        if (_this._onRepeatCallback) {
-                            _this._onRepeatCallback(_this._object);
-                        }
-                        _this._onEveryStartCallbackFired = false;
+                        repeated = true;
                         return true;
                     }
                     else {
-                        if (_this._onCompleteCallback) {
-                            _this._onCompleteCallback(_this._object);
-                        }
-                        for (var i = 0, numChainedTweens = _this._chainedTweens.length; i < numChainedTweens; i++) {
-                            // Make the chained tweens start exactly at the time they should,
-                            // even if the `update()` method was called way past the duration of the tween
-                            _this._chainedTweens[i].start(_this._startTime + _this._duration, false);
-                        }
-                        _this._isPlaying = false;
+                        completed = true;
                         return false;
                     }
                 }
@@ -786,14 +777,31 @@
                 }
             };
             var stillPlaying;
-            // if (true) {
             if (elapsedTime <= this._duration) {
                 doUpdates();
-                stillPlaying = checkStillPlaying();
+                stillPlaying = checkStillPlayingAndReverse();
             }
             else {
-                stillPlaying = checkStillPlaying();
+                stillPlaying = checkStillPlayingAndReverse();
                 doUpdates();
+            }
+            if (repeated) {
+                if (this._onRepeatCallback) {
+                    this._onRepeatCallback(this._object);
+                }
+                this._onEveryStartCallbackFired = false;
+            }
+            if (completed) {
+                completed = true;
+                if (this._onCompleteCallback) {
+                    this._onCompleteCallback(this._object);
+                }
+                for (var i = 0, numChainedTweens = this._chainedTweens.length; i < numChainedTweens; i++) {
+                    // Make the chained tweens start exactly at the time they should,
+                    // even if the `update()` method was called way past the duration of the tween
+                    this._chainedTweens[i].start(this._startTime + this._duration, false);
+                }
+                this._isPlaying = false;
             }
             return stillPlaying;
         };

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1434,6 +1434,44 @@ export const tests = {
 		test.done();
 	},
 
+	'Test yoyo callbacks happen on right order'(test: Test): void {
+		TWEEN.removeAll();
+
+		let events: string[] = [];
+		const obj = { x: 0 }
+
+		new TWEEN.Tween(obj)
+			.to({ x: 100 }, 100)
+			.repeat(1)
+			.yoyo(true)
+			.easing(TWEEN.Easing.Linear.None)
+			.onUpdate(() => events.push('update'))
+			.onStart(() => events.push('start'))
+			.onEveryStart(() => events.push('everystart'))
+			.onRepeat(() => events.push('repeat'))
+			.onComplete(() => events.push('complete'))
+			.start(0);
+
+		function testAndReset(expected: string[]) {
+			test.deepEqual(events, expected);
+			events = [];
+		}
+
+		testAndReset([]);
+		TWEEN.update(99);
+		testAndReset(['start', 'everystart', 'update']);
+		TWEEN.update(101);
+		testAndReset(['update', 'repeat']);
+		TWEEN.update(150);
+		testAndReset(['everystart', 'update']);
+		TWEEN.update(199);
+		testAndReset(['update']);
+		TWEEN.update(201);
+		testAndReset(['update', 'complete']);
+
+		test.done();
+	},
+
 	'Test TWEEN.Tween.stopChainedTweens()'(test: Test): void {
 		const t = new TWEEN.Tween({}),
 			t2 = new TWEEN.Tween({})

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1283,6 +1283,55 @@ export const tests = {
 		test.done()
 	},
 
+	'Test repeat behaves the same with quick and slow updates'(test: Test): void {
+		TWEEN.removeAll()
+
+		const makeTween = (obj: { x: number }) =>
+			new TWEEN.Tween(obj)
+				.to({x: 100}, 100)
+				.repeat(20)
+				.start(0);
+
+		const obj1 = {x: 0};
+		const tween1 = makeTween(obj1);
+
+		for (let t = 0; t <= 300; t += 25) {
+			tween1.update(t);
+
+			const obj2 = {x: 0};
+			const tween2 = makeTween(obj2);
+			tween2.update(t);
+			test.equal(obj1.x, obj2.x, `t=${t}: ${obj1.x} === ${obj2.x}`);
+		}
+
+		test.done()
+	},
+
+	'Test repeat+delay behaves the same with quick and slow updates'(test: Test): void {
+		TWEEN.removeAll()
+
+		const makeTween = (obj: { x: number }) =>
+			new TWEEN.Tween(obj)
+				.to({x: 100}, 100)
+				.delay(50)
+				.repeat(20)
+				.start(0);
+
+		const obj1 = {x: 0};
+		const tween1 = makeTween(obj1);
+
+		for (let t = 0; t <= 300; t += 25) {
+			tween1.update(t);
+
+			const obj2 = {x: 0};
+			const tween2 = makeTween(obj2);
+			tween2.update(t);
+			test.equal(obj1.x, obj2.x, `t=${t}: ${obj1.x} === ${obj2.x}`);
+		}
+
+		test.done()
+	},
+
 	'Test yoyo with repeat Infinity happens forever'(test: Test): void {
 		TWEEN.removeAll()
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1409,6 +1409,31 @@ export const tests = {
 		test.done()
 	},
 
+	'Test yoyo reverses at right instant'(test: Test): void {
+		TWEEN.removeAll();
+
+		const obj = { x: 0 };
+		new TWEEN.Tween(obj).to({ x: 100 }, 100).repeat(1).yoyo(true).start(0);
+
+		TWEEN.update(98);
+		test.equal(obj.x, 98);
+
+		TWEEN.update(99);
+		test.equal(obj.x, 99);
+
+		// Previously this would fail, the first update after 100 would happen as if yoyo=false
+		TWEEN.update(101);
+		test.equal(obj.x, 99);
+
+		TWEEN.update(101);
+		test.equal(obj.x, 99);
+
+		TWEEN.update(102);
+		test.equal(obj.x, 98);
+
+		test.done();
+	},
+
 	'Test TWEEN.Tween.stopChainedTweens()'(test: Test): void {
 		const t = new TWEEN.Tween({}),
 			t2 = new TWEEN.Tween({})

--- a/test/unit/nodeunit.html
+++ b/test/unit/nodeunit.html
@@ -7,6 +7,13 @@
 		<script src="../../.tmp/tests.umd.js"></script>
 	</head>
 	<body>
+		<style>
+			li.fail {
+				color: red;
+				font-weight: bold;
+			}
+		</style>
+
 		<script>
 			nodeunit.run({tween: TWEEN.tests})
 		</script>


### PR DESCRIPTION
fix for https://github.com/tweenjs/tween.js/issues/677

summary:

The current logic first updates the properties, then run the logic that reverses the start and end values for yoyos. The problem is that if the tween has just started repeating, the update will happen before the reversing, so for a single frame the value will be wrong, as if yoyo=false

The proposed fix is to check if the tween has just started to repeat and, if so, apply the yoyo logic before updating the properties

Also, something that I noticed, but I'm not sure if it's intended or not: when the tween repeats, onEveryStart seem to trigger one update later than I would expect. For example:

```ts
new TWEEN.Tween(obj)
    .to({ x: 100 }, 100)
    .repeat(1)
    .yoyo(true)
    .start(0);

TWEEN.update(99); // start everystart update
TWEEN.update(120); // update repeat
TWEEN.update(150); // everystart update
TWEEN.update(199); // update
TWEEN.update(201); // update complete
```

shouldn't everystart happen at 120ms, since the tween has already repeated at that instant?

