### PR TITLE
Tiny readme fix for import-map example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You can import from `node_modules` if you serve node_modules as part of your web
 <script type="importmap">
 	{
 		"imports": {
-			"@tweenjs/tween.js": "./node_modules/@tweenjs/tween.js/dist/tween.es.js"
+			"@tweenjs/tween.js": "./node_modules/@tweenjs/tween.js/dist/tween.esm.js"
 		}
 	}
 </script>

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You can import from `node_modules` if you serve node_modules as part of your web
 <script type="importmap">
 	{
 		"imports": {
-			"@tweenjs/tween.js": "/node_modules/@tweenjs/tween.js/dist/tween.es.js"
+			"@tweenjs/tween.js": "./node_modules/@tweenjs/tween.js/dist/tween.es.js"
 		}
 	}
 </script>


### PR DESCRIPTION
Corrects example so the import-map path is relative.

> Copy and paste current import-map example code it's gonna trigger an error:
> <img width="975" alt="Screenshot 2024-05-12 at 7 05 09 PM" src="https://github.com/tweenjs/tween.js/assets/31227781/71217b60-23e9-484c-9d3e-d99badbce4ff">

Also changes `tween.es.js` => `tween.esm.js`. There does not seem to be any `tween.es.js` available in the default npm install so assume this is a typo.

---

The importmap example code works for me after these two small fixes ✌️