### PR TITLE
feature: implement group-level onComplete callback

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -302,7 +302,7 @@ define(['exports'], (function (exports) { 'use strict';
                 var prevCallback = tween.getCompleteCallback();
                 tween.onComplete(function () {
                     prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
-                    // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                    // After the onComplete callback completes, _isPlaying is updated to false, so if the total number of completed tweens is -1, then they are all complete.
                     var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
                     if (completedGroup.length === group.length - 1)
                         callback(group);

--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -296,6 +296,18 @@ define(['exports'], (function (exports) { 'use strict';
                 tweenIds = Object.keys(this._tweensAddedDuringUpdate);
             }
         };
+        Group.prototype.onComplete = function (callback) {
+            var group = this.getAll();
+            group.forEach(function (tween) {
+                var prevCallback = tween.getCompleteCallback();
+                tween.onComplete(function () {
+                    prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
+                    // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                    if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                        callback(group);
+                });
+            });
+        };
         return Group;
     }());
 
@@ -441,6 +453,9 @@ define(['exports'], (function (exports) { 'use strict';
         }
         Tween.prototype.getId = function () {
             return this._id;
+        };
+        Tween.prototype.getCompleteCallback = function () {
+            return this._onCompleteCallback;
         };
         Tween.prototype.isPlaying = function () {
             return this._isPlaying;

--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -303,7 +303,8 @@ define(['exports'], (function (exports) { 'use strict';
                 tween.onComplete(function () {
                     prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
                     // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
-                    if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                    var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
+                    if (completedGroup.length === group.length - 1)
                         callback(group);
                 });
             });

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -304,7 +304,7 @@ var Group = /** @class */ (function () {
             var prevCallback = tween.getCompleteCallback();
             tween.onComplete(function () {
                 prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
-                // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                // After the onComplete callback completes, _isPlaying is updated to false, so if the total number of completed tweens is -1, then they are all complete.
                 var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
                 if (completedGroup.length === group.length - 1)
                     callback(group);

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -305,7 +305,8 @@ var Group = /** @class */ (function () {
             tween.onComplete(function () {
                 prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
                 // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
-                if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
+                if (completedGroup.length === group.length - 1)
                     callback(group);
             });
         });

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -298,6 +298,18 @@ var Group = /** @class */ (function () {
             tweenIds = Object.keys(this._tweensAddedDuringUpdate);
         }
     };
+    Group.prototype.onComplete = function (callback) {
+        var group = this.getAll();
+        group.forEach(function (tween) {
+            var prevCallback = tween.getCompleteCallback();
+            tween.onComplete(function () {
+                prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
+                // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                    callback(group);
+            });
+        });
+    };
     return Group;
 }());
 
@@ -443,6 +455,9 @@ var Tween = /** @class */ (function () {
     }
     Tween.prototype.getId = function () {
         return this._id;
+    };
+    Tween.prototype.getCompleteCallback = function () {
+        return this._onCompleteCallback;
     };
     Tween.prototype.isPlaying = function () {
         return this._isPlaying;

--- a/dist/tween.d.ts
+++ b/dist/tween.d.ts
@@ -98,6 +98,7 @@ declare class Tween<T extends UnknownProps = any> {
      */
     constructor(object: T, group: true);
     getId(): number;
+    getCompleteCallback(): ((object: T) => void) | undefined;
     isPlaying(): boolean;
     isPaused(): boolean;
     getDuration(): number;
@@ -181,6 +182,7 @@ declare class Group {
      * tweens, and do not rely on tweens being automatically added or removed.
      */
     update(time?: number, preserve?: boolean): void;
+    onComplete(callback: (object: Tween[]) => void): void;
 }
 
 declare const now: () => number;

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -294,6 +294,18 @@ var Group = /** @class */ (function () {
             tweenIds = Object.keys(this._tweensAddedDuringUpdate);
         }
     };
+    Group.prototype.onComplete = function (callback) {
+        var group = this.getAll();
+        group.forEach(function (tween) {
+            var prevCallback = tween.getCompleteCallback();
+            tween.onComplete(function () {
+                prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
+                // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                    callback(group);
+            });
+        });
+    };
     return Group;
 }());
 
@@ -439,6 +451,9 @@ var Tween = /** @class */ (function () {
     }
     Tween.prototype.getId = function () {
         return this._id;
+    };
+    Tween.prototype.getCompleteCallback = function () {
+        return this._onCompleteCallback;
     };
     Tween.prototype.isPlaying = function () {
         return this._isPlaying;

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -300,7 +300,7 @@ var Group = /** @class */ (function () {
             var prevCallback = tween.getCompleteCallback();
             tween.onComplete(function () {
                 prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
-                // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                // After the onComplete callback completes, _isPlaying is updated to false, so if the total number of completed tweens is -1, then they are all complete.
                 var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
                 if (completedGroup.length === group.length - 1)
                     callback(group);

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -301,7 +301,8 @@ var Group = /** @class */ (function () {
             tween.onComplete(function () {
                 prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
                 // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
-                if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
+                if (completedGroup.length === group.length - 1)
                     callback(group);
             });
         });

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -307,7 +307,8 @@
                 tween.onComplete(function () {
                     prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
                     // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
-                    if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                    var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
+                    if (completedGroup.length === group.length - 1)
                         callback(group);
                 });
             });

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -300,6 +300,18 @@
                 tweenIds = Object.keys(this._tweensAddedDuringUpdate);
             }
         };
+        Group.prototype.onComplete = function (callback) {
+            var group = this.getAll();
+            group.forEach(function (tween) {
+                var prevCallback = tween.getCompleteCallback();
+                tween.onComplete(function () {
+                    prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
+                    // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                    if (group.slice(0, group.length - 1).every(function (t) { return !t.isPlaying(); }))
+                        callback(group);
+                });
+            });
+        };
         return Group;
     }());
 
@@ -445,6 +457,9 @@
         }
         Tween.prototype.getId = function () {
             return this._id;
+        };
+        Tween.prototype.getCompleteCallback = function () {
+            return this._onCompleteCallback;
         };
         Tween.prototype.isPlaying = function () {
             return this._isPlaying;

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -306,7 +306,7 @@
                 var prevCallback = tween.getCompleteCallback();
                 tween.onComplete(function () {
                     prevCallback === null || prevCallback === void 0 ? void 0 : prevCallback(tween);
-                    // Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+                    // After the onComplete callback completes, _isPlaying is updated to false, so if the total number of completed tweens is -1, then they are all complete.
                     var completedGroup = group.filter(function (tween) { return !tween.isPlaying(); });
                     if (completedGroup.length === group.length - 1)
                         callback(group);

--- a/src/Group.ts
+++ b/src/Group.ts
@@ -90,8 +90,9 @@ export default class Group {
 			const prevCallback = tween.getCompleteCallback()
 			tween.onComplete(() => {
 				prevCallback?.(tween)
-				// Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
-				if (group.slice(0, group.length - 1).every(t => !t.isPlaying())) callback(group)
+				// After the onComplete callback completes, _isPlaying is updated to false, so if the total number of completed tweens is -1, then they are all complete.
+				const completedGroup = group.filter(tween => !tween.isPlaying())
+				if (completedGroup.length === group.length - 1) callback(group)
 			})
 		})
 	}

--- a/src/Group.ts
+++ b/src/Group.ts
@@ -84,4 +84,15 @@ export default class Group {
 			tweenIds = Object.keys(this._tweensAddedDuringUpdate)
 		}
 	}
+	onComplete(callback: (object: Tween[]) => void) {
+		const group = this.getAll()
+		group.forEach(tween => {
+			const prevCallback = tween.getCompleteCallback()
+			tween.onComplete(() => {
+				prevCallback?.(tween)
+				// Since _isPlaying is updated to false after the onComplete callback finishes, the final tween is omitted from the check to determine if all animations have completed
+				if (group.slice(0, group.length - 1).every(t => !t.isPlaying())) callback(group)
+			})
+		})
+	}
 }

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -83,6 +83,10 @@ export class Tween<T extends UnknownProps = any> {
 		return this._id
 	}
 
+	getCompleteCallback(): ((object: T) => void) | undefined {
+		return this._onCompleteCallback
+	}
+
 	isPlaying(): boolean {
 		return this._isPlaying
 	}

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -2060,6 +2060,53 @@ export const tests = {
 		test.ok(group.getAll() instanceof Array)
 		test.done()
 	},
+	'Custom group.onComplete() should be triggered when all Tweens in the group have reached their completion, and the child Tween.onComplete() should also be fired'(
+		test: Test,
+	): void {
+		TWEEN.removeAll()
+
+		const t = new TWEEN.Tween({x: 1}),
+			t2 = new TWEEN.Tween({x: 1}, true),
+			group = new TWEEN.Group()
+		let groupCounter = 0,
+			childCounter = 0,
+			childCounter2 = 0
+
+		group.add(t)
+		group.add(t2)
+
+		t.to({x: 2}, 1000)
+		t2.to({x: 2}, 2000)
+
+		t.onComplete(function (): void {
+			childCounter++
+		})
+		t2.onComplete(function (): void {
+			childCounter2++
+		})
+		group.onComplete(function (): void {
+			groupCounter++
+		})
+
+		t.start(0)
+		t2.start(0)
+
+		group.update(0)
+		test.deepEqual(groupCounter, 0)
+		test.deepEqual(childCounter, 0)
+		test.deepEqual(childCounter2, 0)
+
+		group.update(1000)
+		test.deepEqual(groupCounter, 0)
+		test.deepEqual(childCounter, 1)
+		test.deepEqual(childCounter2, 0)
+
+		group.update(2000)
+		test.deepEqual(childCounter, 1)
+		test.deepEqual(groupCounter, 1)
+		test.deepEqual(childCounter2, 1)
+		test.done()
+	},
 
 	'Custom group stores tweens instead of global TWEEN group'(test: Test): void {
 		const group = new TWEEN.Group()

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -2066,17 +2066,21 @@ export const tests = {
 		TWEEN.removeAll()
 
 		const t = new TWEEN.Tween({x: 1}),
-			t2 = new TWEEN.Tween({x: 1}, true),
+			t2 = new TWEEN.Tween({x: 1}),
+			t3 = new TWEEN.Tween({x: 1}),
 			group = new TWEEN.Group()
 		let groupCounter = 0,
 			childCounter = 0,
-			childCounter2 = 0
+			childCounter2 = 0,
+			childCounter3 = 0
 
 		group.add(t)
 		group.add(t2)
+		group.add(t3)
 
 		t.to({x: 2}, 1000)
 		t2.to({x: 2}, 2000)
+		t3.to({x: 2}, 3000)
 
 		t.onComplete(function (): void {
 			childCounter++
@@ -2084,27 +2088,40 @@ export const tests = {
 		t2.onComplete(function (): void {
 			childCounter2++
 		})
+		t3.onComplete(function (): void {
+			childCounter3++
+		})
 		group.onComplete(function (): void {
 			groupCounter++
 		})
 
 		t.start(0)
 		t2.start(0)
+		t3.start(0)
 
 		group.update(0)
 		test.deepEqual(groupCounter, 0)
 		test.deepEqual(childCounter, 0)
 		test.deepEqual(childCounter2, 0)
+		test.deepEqual(childCounter3, 0)
 
 		group.update(1000)
 		test.deepEqual(groupCounter, 0)
 		test.deepEqual(childCounter, 1)
 		test.deepEqual(childCounter2, 0)
+		test.deepEqual(childCounter3, 0)
 
 		group.update(2000)
 		test.deepEqual(childCounter, 1)
-		test.deepEqual(groupCounter, 1)
+		test.deepEqual(groupCounter, 0)
 		test.deepEqual(childCounter2, 1)
+		test.deepEqual(childCounter3, 0)
+
+		group.update(3000)
+		test.deepEqual(groupCounter, 1)
+		test.deepEqual(childCounter, 1)
+		test.deepEqual(childCounter2, 1)
+		test.deepEqual(childCounter3, 1)
 		test.done()
 	},
 


### PR DESCRIPTION
Hello, I’m always using TweenJS well!

While using it, I thought of a feature that I would like to see added, so I decided to create it myself!

This PR adds a onComplete property to Tween.Group, allowing you to specify a callback function that will be called when all tweens in the group have completed. Individual tween onComplete callbacks will still be triggered as expected