### PR TITLE
#697: Added "setNow"

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -215,7 +215,13 @@ define(['exports'], (function (exports) { 'use strict';
         },
     });
 
-    var now = function () { return performance.now(); };
+    var _nowFunc = function () { return performance.now(); };
+    var now = function () {
+        return _nowFunc();
+    };
+    function setNow(nowFunction) {
+        _nowFunc = nowFunction;
+    }
 
     /**
      * Controlling groups of tweens
@@ -1139,6 +1145,7 @@ define(['exports'], (function (exports) { 'use strict';
         Group: Group,
         Interpolation: Interpolation,
         now: now,
+        setNow: setNow,
         Sequence: Sequence,
         nextId: nextId,
         Tween: Tween,
@@ -1398,6 +1405,7 @@ define(['exports'], (function (exports) { 'use strict';
     exports.now = now;
     exports.remove = remove;
     exports.removeAll = removeAll;
+    exports.setNow = setNow;
     exports.update = update;
 
     Object.defineProperty(exports, '__esModule', { value: true });

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -217,7 +217,13 @@ var Easing = Object.freeze({
     },
 });
 
-var now = function () { return performance.now(); };
+var _nowFunc = function () { return performance.now(); };
+var now = function () {
+    return _nowFunc();
+};
+function setNow(nowFunction) {
+    _nowFunc = nowFunction;
+}
 
 /**
  * Controlling groups of tweens
@@ -1141,6 +1147,7 @@ var exports$1 = {
     Group: Group,
     Interpolation: Interpolation,
     now: now,
+    setNow: setNow,
     Sequence: Sequence,
     nextId: nextId,
     Tween: Tween,
@@ -1400,4 +1407,5 @@ exports.nextId = nextId;
 exports.now = now;
 exports.remove = remove;
 exports.removeAll = removeAll;
+exports.setNow = setNow;
 exports.update = update;

--- a/dist/tween.d.ts
+++ b/dist/tween.d.ts
@@ -184,6 +184,7 @@ declare class Group {
 }
 
 declare const now: () => number;
+declare function setNow(nowFunction: Function): void;
 
 /**
  * Utils
@@ -470,6 +471,7 @@ declare const exports: {
         };
     };
     now: () => number;
+    setNow: typeof setNow;
     Sequence: typeof Sequence;
     nextId: typeof Sequence.nextId;
     Tween: typeof Tween;
@@ -719,4 +721,4 @@ declare const exports: {
     };
 };
 
-export { Easing, Group, Interpolation, Sequence, Tween, VERSION, add, exports as default, getAll, nextId, now, remove, removeAll, update };
+export { Easing, Group, Interpolation, Sequence, Tween, VERSION, add, exports as default, getAll, nextId, now, remove, removeAll, setNow, update };

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -213,7 +213,13 @@ var Easing = Object.freeze({
     },
 });
 
-var now = function () { return performance.now(); };
+var _nowFunc = function () { return performance.now(); };
+var now = function () {
+    return _nowFunc();
+};
+function setNow(nowFunction) {
+    _nowFunc = nowFunction;
+}
 
 /**
  * Controlling groups of tweens
@@ -1137,6 +1143,7 @@ var exports = {
     Group: Group,
     Interpolation: Interpolation,
     now: now,
+    setNow: setNow,
     Sequence: Sequence,
     nextId: nextId,
     Tween: Tween,
@@ -1383,4 +1390,4 @@ var exports = {
     update: update,
 };
 
-export { Easing, Group, Interpolation, Sequence, Tween, VERSION, add, exports as default, getAll, nextId, now, remove, removeAll, update };
+export { Easing, Group, Interpolation, Sequence, Tween, VERSION, add, exports as default, getAll, nextId, now, remove, removeAll, setNow, update };

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -219,7 +219,13 @@
         },
     });
 
-    var now = function () { return performance.now(); };
+    var _nowFunc = function () { return performance.now(); };
+    var now = function () {
+        return _nowFunc();
+    };
+    function setNow(nowFunction) {
+        _nowFunc = nowFunction;
+    }
 
     /**
      * Controlling groups of tweens
@@ -1143,6 +1149,7 @@
         Group: Group,
         Interpolation: Interpolation,
         now: now,
+        setNow: setNow,
         Sequence: Sequence,
         nextId: nextId,
         Tween: Tween,
@@ -1402,6 +1409,7 @@
     exports.now = now;
     exports.remove = remove;
     exports.removeAll = removeAll;
+    exports.setNow = setNow;
     exports.update = update;
 
     Object.defineProperty(exports, '__esModule', { value: true });

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -642,6 +642,12 @@ Note that the interpolation function is global to all properties that are tweene
 
 Check [06_array_interpolation](../examples/06_array_interpolation.html) for an example.
 
+## Changing the Definition of "Now"
+
+When working with tweening, you inevitably rely on a definition of what "now" is. By default, Tween.js uses performance.now, which is a reliable and precise approach. However, if you need to adjust the flow of time—for instance, to slow it down or manipulate it for a custom purpose—you may encounter discrepancies between your internal definition of "now" and what Tween.js considers "now."
+
+To address this, a new function, setNow, has been introduced. This function allows you to redefine the internal "now" used by Tween.js. You can pass a custom function to setNow, which will replace the default definition. This provides greater flexibility and enables synchronization with your specific requirements for time control.
+
 ## Getting the best performance
 
 While Tween.js tries to be performant on its own, nothing prevents you from using it in a way that is counterperformant. Here are some of the ways you can avoid slowing down your projects when using Tween.js (or when animating in the web, in general).

--- a/scripts/write-version.js
+++ b/scripts/write-version.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import pkg from '../package.json' assert {type: 'json'}
+import pkg from '../package.json' with {type: 'json'}
 
 const {version} = pkg
 

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -10,7 +10,7 @@
 import Easing from './Easing'
 import Group from './Group'
 import Interpolation from './Interpolation'
-import now from './Now'
+import now, { setNow } from './Now'
 import Sequence from './Sequence'
 import Tween from './Tween'
 import VERSION from './Version'
@@ -273,13 +273,14 @@ const update = TWEEN.update.bind(TWEEN)
 
 // NOTE! Make sure both lists of exports below are kept in sync:
 
-export {Easing, Group, Interpolation, now, Sequence, nextId, Tween, VERSION, getAll, removeAll, add, remove, update}
+export {Easing, Group, Interpolation, now, setNow, Sequence, nextId, Tween, VERSION, getAll, removeAll, add, remove, update}
 
 const exports = {
 	Easing,
 	Group,
 	Interpolation,
 	now,
+	setNow,
 	Sequence,
 	nextId,
 	Tween,

--- a/src/Now.ts
+++ b/src/Now.ts
@@ -1,3 +1,11 @@
-const now = (): number => performance.now()
+let _nowFunc: Function = () => performance.now()
+
+const now = (): number => {
+  return _nowFunc()
+}
+
+export function setNow(nowFunction: Function) {
+  _nowFunc = nowFunction
+}
 
 export default now


### PR DESCRIPTION
Added the ability to override the internal "now" function using the "setNow" function.

It simply takes the new function you want to override the default "performance.now" implementation.

Useful when you want to control the flow of time on a global scale in a dynamic manner.