### PR TITLE
Add new easing function generators: generateBack, generateElastic, generateSteps

### DIFF
--- a/dist/tween.amd.js
+++ b/dist/tween.amd.js
@@ -213,6 +213,79 @@ define(['exports'], (function (exports) { 'use strict';
                 },
             };
         },
+        generateBack: function (overshoot) {
+            if (overshoot === void 0) { overshoot = 1.70158; }
+            var s = overshoot;
+            return {
+                In: function (amount) {
+                    return amount === 1 ? 1 : amount * amount * ((s + 1) * amount - s);
+                },
+                Out: function (amount) {
+                    return amount === 0 ? 0 : --amount * amount * ((s + 1) * amount + s) + 1;
+                },
+                InOut: function (amount) {
+                    var s2 = s * 1.525;
+                    if ((amount *= 2) < 1) {
+                        return 0.5 * (amount * amount * ((s2 + 1) * amount - s2));
+                    }
+                    return 0.5 * ((amount -= 2) * amount * ((s2 + 1) * amount + s2) + 2);
+                },
+            };
+        },
+        generateElastic: function (amplitude, period) {
+            if (amplitude === void 0) { amplitude = 1; }
+            if (period === void 0) { period = 0.3; }
+            var a = Math.max(1, amplitude);
+            var p = period;
+            var s = (p / (2 * Math.PI)) * Math.asin(1 / a);
+            var pIO = p * 1.5;
+            var sIO = (pIO / (2 * Math.PI)) * Math.asin(1 / a);
+            return {
+                In: function (amount) {
+                    if (amount === 0)
+                        return 0;
+                    if (amount === 1)
+                        return 1;
+                    return -(a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - s) * (2 * Math.PI) / p));
+                },
+                Out: function (amount) {
+                    if (amount === 0)
+                        return 0;
+                    if (amount === 1)
+                        return 1;
+                    return a * Math.pow(2, -10 * amount) * Math.sin((amount - s) * (2 * Math.PI) / p) + 1;
+                },
+                InOut: function (amount) {
+                    if (amount === 0)
+                        return 0;
+                    if (amount === 1)
+                        return 1;
+                    amount *= 2;
+                    if (amount < 1) {
+                        return -0.5 * (a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO));
+                    }
+                    return 0.5 * (a * Math.pow(2, -10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO)) + 1;
+                },
+            };
+        },
+        generateSteps: function (steps) {
+            if (steps === void 0) { steps = 10; }
+            steps = Math.max(1, Math.floor(steps));
+            return {
+                In: function (amount) {
+                    return Math.ceil(amount * steps) / steps;
+                },
+                Out: function (amount) {
+                    return Math.floor(amount * steps) / steps;
+                },
+                InOut: function (amount) {
+                    if (amount <= 0.5) {
+                        return Math.ceil(amount * steps * 2) / (steps * 2);
+                    }
+                    return (Math.floor((amount - 0.5) * steps * 2) + steps) / (steps * 2);
+                },
+            };
+        },
     });
 
     var _nowFunc = function () { return performance.now(); };

--- a/dist/tween.cjs
+++ b/dist/tween.cjs
@@ -215,6 +215,79 @@ var Easing = Object.freeze({
             },
         };
     },
+    generateBack: function (overshoot) {
+        if (overshoot === void 0) { overshoot = 1.70158; }
+        var s = overshoot;
+        return {
+            In: function (amount) {
+                return amount === 1 ? 1 : amount * amount * ((s + 1) * amount - s);
+            },
+            Out: function (amount) {
+                return amount === 0 ? 0 : --amount * amount * ((s + 1) * amount + s) + 1;
+            },
+            InOut: function (amount) {
+                var s2 = s * 1.525;
+                if ((amount *= 2) < 1) {
+                    return 0.5 * (amount * amount * ((s2 + 1) * amount - s2));
+                }
+                return 0.5 * ((amount -= 2) * amount * ((s2 + 1) * amount + s2) + 2);
+            },
+        };
+    },
+    generateElastic: function (amplitude, period) {
+        if (amplitude === void 0) { amplitude = 1; }
+        if (period === void 0) { period = 0.3; }
+        var a = Math.max(1, amplitude);
+        var p = period;
+        var s = (p / (2 * Math.PI)) * Math.asin(1 / a);
+        var pIO = p * 1.5;
+        var sIO = (pIO / (2 * Math.PI)) * Math.asin(1 / a);
+        return {
+            In: function (amount) {
+                if (amount === 0)
+                    return 0;
+                if (amount === 1)
+                    return 1;
+                return -(a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - s) * (2 * Math.PI) / p));
+            },
+            Out: function (amount) {
+                if (amount === 0)
+                    return 0;
+                if (amount === 1)
+                    return 1;
+                return a * Math.pow(2, -10 * amount) * Math.sin((amount - s) * (2 * Math.PI) / p) + 1;
+            },
+            InOut: function (amount) {
+                if (amount === 0)
+                    return 0;
+                if (amount === 1)
+                    return 1;
+                amount *= 2;
+                if (amount < 1) {
+                    return -0.5 * (a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO));
+                }
+                return 0.5 * (a * Math.pow(2, -10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO)) + 1;
+            },
+        };
+    },
+    generateSteps: function (steps) {
+        if (steps === void 0) { steps = 10; }
+        steps = Math.max(1, Math.floor(steps));
+        return {
+            In: function (amount) {
+                return Math.ceil(amount * steps) / steps;
+            },
+            Out: function (amount) {
+                return Math.floor(amount * steps) / steps;
+            },
+            InOut: function (amount) {
+                if (amount <= 0.5) {
+                    return Math.ceil(amount * steps * 2) / (steps * 2);
+                }
+                return (Math.floor((amount - 0.5) * steps * 2) + steps) / (steps * 2);
+            },
+        };
+    },
 });
 
 var _nowFunc = function () { return performance.now(); };

--- a/dist/tween.d.ts
+++ b/dist/tween.d.ts
@@ -22,6 +22,9 @@ declare const Easing: Readonly<{
     Back: Readonly<EasingFunctionGroup>;
     Bounce: Readonly<EasingFunctionGroup>;
     generatePow(power?: number): EasingFunctionGroup;
+    generateBack(overshoot?: number): EasingFunctionGroup;
+    generateElastic(amplitude?: number, period?: number): EasingFunctionGroup;
+    generateSteps(steps?: number): EasingFunctionGroup;
 }>;
 
 /**
@@ -459,6 +462,9 @@ declare const exports: {
         Back: Readonly<EasingFunctionGroup>;
         Bounce: Readonly<EasingFunctionGroup>;
         generatePow(power?: number): EasingFunctionGroup;
+        generateBack(overshoot?: number): EasingFunctionGroup;
+        generateElastic(amplitude?: number, period?: number): EasingFunctionGroup;
+        generateSteps(steps?: number): EasingFunctionGroup;
     }>;
     Group: typeof Group;
     Interpolation: {

--- a/dist/tween.esm.js
+++ b/dist/tween.esm.js
@@ -211,6 +211,79 @@ var Easing = Object.freeze({
             },
         };
     },
+    generateBack: function (overshoot) {
+        if (overshoot === void 0) { overshoot = 1.70158; }
+        var s = overshoot;
+        return {
+            In: function (amount) {
+                return amount === 1 ? 1 : amount * amount * ((s + 1) * amount - s);
+            },
+            Out: function (amount) {
+                return amount === 0 ? 0 : --amount * amount * ((s + 1) * amount + s) + 1;
+            },
+            InOut: function (amount) {
+                var s2 = s * 1.525;
+                if ((amount *= 2) < 1) {
+                    return 0.5 * (amount * amount * ((s2 + 1) * amount - s2));
+                }
+                return 0.5 * ((amount -= 2) * amount * ((s2 + 1) * amount + s2) + 2);
+            },
+        };
+    },
+    generateElastic: function (amplitude, period) {
+        if (amplitude === void 0) { amplitude = 1; }
+        if (period === void 0) { period = 0.3; }
+        var a = Math.max(1, amplitude);
+        var p = period;
+        var s = (p / (2 * Math.PI)) * Math.asin(1 / a);
+        var pIO = p * 1.5;
+        var sIO = (pIO / (2 * Math.PI)) * Math.asin(1 / a);
+        return {
+            In: function (amount) {
+                if (amount === 0)
+                    return 0;
+                if (amount === 1)
+                    return 1;
+                return -(a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - s) * (2 * Math.PI) / p));
+            },
+            Out: function (amount) {
+                if (amount === 0)
+                    return 0;
+                if (amount === 1)
+                    return 1;
+                return a * Math.pow(2, -10 * amount) * Math.sin((amount - s) * (2 * Math.PI) / p) + 1;
+            },
+            InOut: function (amount) {
+                if (amount === 0)
+                    return 0;
+                if (amount === 1)
+                    return 1;
+                amount *= 2;
+                if (amount < 1) {
+                    return -0.5 * (a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO));
+                }
+                return 0.5 * (a * Math.pow(2, -10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO)) + 1;
+            },
+        };
+    },
+    generateSteps: function (steps) {
+        if (steps === void 0) { steps = 10; }
+        steps = Math.max(1, Math.floor(steps));
+        return {
+            In: function (amount) {
+                return Math.ceil(amount * steps) / steps;
+            },
+            Out: function (amount) {
+                return Math.floor(amount * steps) / steps;
+            },
+            InOut: function (amount) {
+                if (amount <= 0.5) {
+                    return Math.ceil(amount * steps * 2) / (steps * 2);
+                }
+                return (Math.floor((amount - 0.5) * steps * 2) + steps) / (steps * 2);
+            },
+        };
+    },
 });
 
 var _nowFunc = function () { return performance.now(); };

--- a/dist/tween.umd.js
+++ b/dist/tween.umd.js
@@ -217,6 +217,79 @@
                 },
             };
         },
+        generateBack: function (overshoot) {
+            if (overshoot === void 0) { overshoot = 1.70158; }
+            var s = overshoot;
+            return {
+                In: function (amount) {
+                    return amount === 1 ? 1 : amount * amount * ((s + 1) * amount - s);
+                },
+                Out: function (amount) {
+                    return amount === 0 ? 0 : --amount * amount * ((s + 1) * amount + s) + 1;
+                },
+                InOut: function (amount) {
+                    var s2 = s * 1.525;
+                    if ((amount *= 2) < 1) {
+                        return 0.5 * (amount * amount * ((s2 + 1) * amount - s2));
+                    }
+                    return 0.5 * ((amount -= 2) * amount * ((s2 + 1) * amount + s2) + 2);
+                },
+            };
+        },
+        generateElastic: function (amplitude, period) {
+            if (amplitude === void 0) { amplitude = 1; }
+            if (period === void 0) { period = 0.3; }
+            var a = Math.max(1, amplitude);
+            var p = period;
+            var s = (p / (2 * Math.PI)) * Math.asin(1 / a);
+            var pIO = p * 1.5;
+            var sIO = (pIO / (2 * Math.PI)) * Math.asin(1 / a);
+            return {
+                In: function (amount) {
+                    if (amount === 0)
+                        return 0;
+                    if (amount === 1)
+                        return 1;
+                    return -(a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - s) * (2 * Math.PI) / p));
+                },
+                Out: function (amount) {
+                    if (amount === 0)
+                        return 0;
+                    if (amount === 1)
+                        return 1;
+                    return a * Math.pow(2, -10 * amount) * Math.sin((amount - s) * (2 * Math.PI) / p) + 1;
+                },
+                InOut: function (amount) {
+                    if (amount === 0)
+                        return 0;
+                    if (amount === 1)
+                        return 1;
+                    amount *= 2;
+                    if (amount < 1) {
+                        return -0.5 * (a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO));
+                    }
+                    return 0.5 * (a * Math.pow(2, -10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO)) + 1;
+                },
+            };
+        },
+        generateSteps: function (steps) {
+            if (steps === void 0) { steps = 10; }
+            steps = Math.max(1, Math.floor(steps));
+            return {
+                In: function (amount) {
+                    return Math.ceil(amount * steps) / steps;
+                },
+                Out: function (amount) {
+                    return Math.floor(amount * steps) / steps;
+                },
+                InOut: function (amount) {
+                    if (amount <= 0.5) {
+                        return Math.ceil(amount * steps * 2) / (steps * 2);
+                    }
+                    return (Math.floor((amount - 0.5) * steps * 2) + steps) / (steps * 2);
+                },
+            };
+        },
     });
 
     var _nowFunc = function () { return performance.now(); };

--- a/examples/03_graphs.html
+++ b/examples/03_graphs.html
@@ -89,6 +89,25 @@
 				target.appendChild(createGraph(group, 'Bounce.In', TWEEN.Easing.Bounce.In))
 				target.appendChild(createGraph(group, 'Bounce.Out', TWEEN.Easing.Bounce.Out))
 				target.appendChild(createGraph(group, 'Bounce.InOut', TWEEN.Easing.Bounce.InOut))
+
+				target.appendChild(document.createElement('br'))
+
+				const customBack = TWEEN.Easing.generateBack(3)
+				target.appendChild(createGraph(group, 'generateBack(3).In', customBack.In))
+				target.appendChild(createGraph(group, 'generateBack(3).Out', customBack.Out))
+				target.appendChild(createGraph(group, 'generateBack(3).InOut', customBack.InOut))
+
+				const customElastic = TWEEN.Easing.generateElastic(1.5, 0.4)
+				target.appendChild(createGraph(group, 'generateElastic(1.5,0.4).In', customElastic.In))
+				target.appendChild(createGraph(group, 'generateElastic(1.5,0.4).Out', customElastic.Out))
+				target.appendChild(createGraph(group, 'generateElastic(1.5,0.4).InOut', customElastic.InOut))
+
+				target.appendChild(document.createElement('br'))
+
+				const steps4 = TWEEN.Easing.generateSteps(4)
+				target.appendChild(createGraph(group, 'generateSteps(4).In', steps4.In))
+				target.appendChild(createGraph(group, 'generateSteps(4).Out', steps4.Out))
+				target.appendChild(createGraph(group, 'generateSteps(4).InOut', steps4.InOut))
 			}
 
 			function animate(time) {

--- a/src/Easing.ts
+++ b/src/Easing.ts
@@ -240,6 +240,72 @@ export const Easing = Object.freeze({
 			},
 		}
 	},
+
+	generateBack(overshoot = 1.70158): EasingFunctionGroup {
+		const s = overshoot
+		return {
+			In(amount: number): number {
+				return amount === 1 ? 1 : amount * amount * ((s + 1) * amount - s)
+			},
+			Out(amount: number): number {
+				return amount === 0 ? 0 : --amount * amount * ((s + 1) * amount + s) + 1
+			},
+			InOut(amount: number): number {
+				const s2 = s * 1.525
+				if ((amount *= 2) < 1) {
+					return 0.5 * (amount * amount * ((s2 + 1) * amount - s2))
+				}
+				return 0.5 * ((amount -= 2) * amount * ((s2 + 1) * amount + s2) + 2)
+			},
+		}
+	},
+
+	generateElastic(amplitude = 1, period = 0.3): EasingFunctionGroup {
+		const a = Math.max(1, amplitude)
+		const p = period
+		const s = (p / (2 * Math.PI)) * Math.asin(1 / a)
+		const pIO = p * 1.5
+		const sIO = (pIO / (2 * Math.PI)) * Math.asin(1 / a)
+		return {
+			In(amount: number): number {
+				if (amount === 0) return 0
+				if (amount === 1) return 1
+				return -(a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - s) * (2 * Math.PI) / p))
+			},
+			Out(amount: number): number {
+				if (amount === 0) return 0
+				if (amount === 1) return 1
+				return a * Math.pow(2, -10 * amount) * Math.sin((amount - s) * (2 * Math.PI) / p) + 1
+			},
+			InOut(amount: number): number {
+				if (amount === 0) return 0
+				if (amount === 1) return 1
+				amount *= 2
+				if (amount < 1) {
+					return -0.5 * (a * Math.pow(2, 10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO))
+				}
+				return 0.5 * (a * Math.pow(2, -10 * (amount - 1)) * Math.sin(((amount - 1) - sIO) * (2 * Math.PI) / pIO)) + 1
+			},
+		}
+	},
+
+	generateSteps(steps = 10): EasingFunctionGroup {
+		steps = Math.max(1, Math.floor(steps))
+		return {
+			In(amount: number): number {
+				return Math.ceil(amount * steps) / steps
+			},
+			Out(amount: number): number {
+				return Math.floor(amount * steps) / steps
+			},
+			InOut(amount: number): number {
+				if (amount <= 0.5) {
+					return Math.ceil(amount * steps * 2) / (steps * 2)
+				}
+				return (Math.floor((amount - 0.5) * steps * 2) + steps) / (steps * 2)
+			},
+		}
+	},
 })
 
 export default Easing

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -2650,6 +2650,106 @@ export const tests = {
 		test.done()
 	},
 
+	'Test TWEEN.Easing.generateBack() should match default Back at default overshoot'(test: Test): void {
+		const defaultBack = TWEEN.Easing.generateBack()
+		const amount = Math.LOG10E
+		toBeCloseTo(test, defaultBack.In(amount), TWEEN.Easing.Back.In(amount), 14)
+		toBeCloseTo(test, defaultBack.Out(amount), TWEEN.Easing.Back.Out(amount), 14)
+		toBeCloseTo(test, defaultBack.InOut(amount), TWEEN.Easing.Back.InOut(amount), 14)
+		test.done()
+	},
+
+	'Test TWEEN.Easing.generateBack(n) should pass 0.0, 0.5, 1.0'(test: Test): void {
+		const checkEdgeValue = (ease: EasingFunctionGroup) => {
+			test.equal(ease.InOut(0.0), 0.0)
+			test.equal(ease.In(0.0), 0.0)
+			test.equal(ease.Out(0.0), 0.0)
+
+			test.equal(ease.InOut(0.5), 0.5)
+
+			test.equal(ease.InOut(1.0), 1.0)
+			test.equal(ease.In(1.0), 1.0)
+			test.equal(ease.Out(1.0), 1.0)
+		}
+		checkEdgeValue(TWEEN.Easing.generateBack(0))
+		checkEdgeValue(TWEEN.Easing.generateBack(1.0))
+		checkEdgeValue(TWEEN.Easing.generateBack())
+		checkEdgeValue(TWEEN.Easing.generateBack(2.5))
+		checkEdgeValue(TWEEN.Easing.generateBack(5.0))
+		test.done()
+	},
+
+	'Test TWEEN.Easing.generateElastic() should pass 0.0, 0.5, 1.0'(test: Test): void {
+		const checkEdgeValue = (ease: EasingFunctionGroup) => {
+			test.equal(ease.In(0.0), 0.0)
+			test.equal(ease.Out(0.0), 0.0)
+			test.equal(ease.InOut(0.0), 0.0)
+
+			toBeCloseTo(test, ease.InOut(0.5), 0.5, 10)
+
+			test.equal(ease.In(1.0), 1.0)
+			test.equal(ease.Out(1.0), 1.0)
+			test.equal(ease.InOut(1.0), 1.0)
+		}
+		checkEdgeValue(TWEEN.Easing.generateElastic())
+		checkEdgeValue(TWEEN.Easing.generateElastic(1, 0.3))
+		checkEdgeValue(TWEEN.Easing.generateElastic(1.5, 0.4))
+		checkEdgeValue(TWEEN.Easing.generateElastic(2, 0.5))
+		test.done()
+	},
+
+	'Test TWEEN.Easing.generateSteps() should pass 0.0, 0.5, 1.0'(test: Test): void {
+		const checkEdgeValue = (ease: EasingFunctionGroup) => {
+			test.equal(ease.In(0.0), 0.0)
+			test.equal(ease.Out(0.0), 0.0)
+			test.equal(ease.InOut(0.0), 0.0)
+
+			test.equal(ease.In(1.0), 1.0)
+			test.equal(ease.Out(1.0), 1.0)
+			test.equal(ease.InOut(1.0), 1.0)
+		}
+		checkEdgeValue(TWEEN.Easing.generateSteps(1))
+		checkEdgeValue(TWEEN.Easing.generateSteps(4))
+		checkEdgeValue(TWEEN.Easing.generateSteps())
+		checkEdgeValue(TWEEN.Easing.generateSteps(100))
+		test.done()
+	},
+
+	'Test TWEEN.Easing.generateSteps() produces discrete values'(test: Test): void {
+		const steps4 = TWEEN.Easing.generateSteps(4)
+
+		test.equal(steps4.In(0.0), 0.0)
+		test.equal(steps4.In(0.1), 0.25)
+		test.equal(steps4.In(0.25), 0.25)
+		test.equal(steps4.In(0.3), 0.5)
+		test.equal(steps4.In(0.5), 0.5)
+		test.equal(steps4.In(0.7), 0.75)
+		test.equal(steps4.In(0.75), 0.75)
+		test.equal(steps4.In(0.9), 1.0)
+		test.equal(steps4.In(1.0), 1.0)
+
+		test.equal(steps4.Out(0.0), 0.0)
+		test.equal(steps4.Out(0.1), 0.0)
+		test.equal(steps4.Out(0.25), 0.25)
+		test.equal(steps4.Out(0.5), 0.5)
+		test.equal(steps4.Out(0.7), 0.5)
+		test.equal(steps4.Out(0.75), 0.75)
+		test.equal(steps4.Out(1.0), 1.0)
+
+		test.done()
+	},
+
+	'Test TWEEN.Easing.generateSteps() InOut should be 0.5 at midpoint'(test: Test): void {
+		test.equal(TWEEN.Easing.generateSteps(1).InOut(0.5), 0.5)
+		test.equal(TWEEN.Easing.generateSteps(2).InOut(0.5), 0.5)
+		test.equal(TWEEN.Easing.generateSteps(3).InOut(0.5), 0.5)
+		test.equal(TWEEN.Easing.generateSteps(4).InOut(0.5), 0.5)
+		test.equal(TWEEN.Easing.generateSteps(5).InOut(0.5), 0.5)
+		test.equal(TWEEN.Easing.generateSteps(10).InOut(0.5), 0.5)
+		test.equal(TWEEN.Easing.generateSteps(100).InOut(0.5), 0.5)
+		test.done()
+	},
+
 	'Test TWEEN.Easing.generatePow(n) should pass 0.0, 0.5, 1.0'(test: Test): void {
 		const checkEdgeValue = (ease: EasingFunctionGroup) => {
 			test.equal(ease.InOut(0.0), 0.0)


### PR DESCRIPTION
## Summary

Adds three new configurable easing generators to complement the existing `generatePow`, as requested in #507:

- **`generateBack(overshoot)`** — Back easing with custom overshoot (default `1.70158`, matching the built-in `Back`). Higher values produce more dramatic overshoots.
- **`generateElastic(amplitude, period)`** — Elastic easing with configurable amplitude (≥1) and period. Useful for springy animations where you need fine control over the bounce.
- **`generateSteps(steps)`** — Discrete step easing that quantizes the animation into N steps. In variant jumps at the start of each interval, Out at the end, InOut combines both halves. Useful for sprite sheet animations and staircase effects.

All generators return `EasingFunctionGroup` (In/Out/InOut) and satisfy the standard edge-value contracts:
- `f(0) = 0`
- `f(1) = 1`
- `InOut(0.5) = 0.5`

### Changes
- `src/Easing.ts` — added the three generator functions
- `src/tests.ts` — added 7 test cases covering edge values, discrete step behavior, midpoint constraints, and `generateBack` parity with default `Back`
- `examples/03_graphs.html` — added visual demos for the new generators

### Usage

```js
import { Easing } from '@tweenjs/tween.js'

// Back with stronger overshoot
const strongBack = Easing.generateBack(3)
tween.easing(strongBack.InOut)

// Elastic with more bounce
const springy = Easing.generateElastic(1.5, 0.4)
tween.easing(springy.Out)

// 4-step staircase
const steps = Easing.generateSteps(4)
tween.easing(steps.In)
```

Closes #507